### PR TITLE
Added support for IIIF selector

### DIFF
--- a/__tests__/exhibition-helpers.test.ts
+++ b/__tests__/exhibition-helpers.test.ts
@@ -1,0 +1,41 @@
+import novieten from '../fixtures/exhibitions/novieten.json';
+import { Vault } from '@iiif/vault';
+import { CanvasNormalized, Manifest } from '@iiif/presentation-3';
+import invariant from 'tiny-invariant';
+import { createPaintingAnnotationsHelper } from '../src/painting-annotations';
+import { expandTarget } from '../src';
+
+describe('Exhibition helpers', () => {
+  test('parsing exhibition', async () => {
+    const vault = new Vault();
+    const manifest = await vault.load<Manifest>(novieten.id, novieten);
+
+    expect(manifest).to.exist;
+    invariant(manifest);
+
+    const canvases = vault.get<CanvasNormalized>(manifest.items);
+    const painting = createPaintingAnnotationsHelper(vault);
+
+    const paintables = painting.getPaintables(canvases[0]);
+    expect(paintables.items).toHaveLength(1);
+
+    const expanded = expandTarget({
+      type: 'SpecificResource',
+      source: paintables.items[0].resource,
+      selector: paintables.items[0].selector,
+    });
+
+    expect(expanded.selector).toMatchInlineSnapshot(`
+      {
+        "spatial": {
+          "height": 2749,
+          "unit": "pixel",
+          "width": 2666,
+          "x": 559,
+          "y": 0,
+        },
+        "type": "BoxSelector",
+      }
+    `);
+  });
+});

--- a/fixtures/exhibitions/novieten.json
+++ b/fixtures/exhibitions/novieten.json
@@ -1,0 +1,3845 @@
+{
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  "type": "Manifest",
+  "label": {
+    "nl": [
+      "Novieten"
+    ],
+    "en": [
+      "Novices"
+    ]
+  },
+  "items": [
+    {
+      "label": {
+        "nl": [
+          "De enige vrouw in de collegezaal"
+        ],
+        "en": [
+          "The only woman in the lecture hal"
+        ]
+      },
+      "height": 2749,
+      "width": 2666,
+      "type": "Canvas",
+      "items": [
+        {
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "motivation": "painting",
+              "type": "Annotation",
+              "body": {
+                "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/1a5e682f-f7fc-f089-a448-91cd572b7a77/specificResource",
+                "type": "SpecificResource",
+                "source": {
+                  "id": "https://dlc.services/iiif-img/7/21/e16c7a6b-9672-d551-70d7-08c88609efb1/full/full/0/default.jpg",
+                  "type": "Image",
+                  "format": "image/jpeg",
+                  "height": 2749,
+                  "width": 3637,
+                  "label": {
+                    "nl": [
+                      "-"
+                    ]
+                  },
+                  "service": {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/iiif-img/7/21/e16c7a6b-9672-d551-70d7-08c88609efb1",
+                    "protocol": "http://iiif.io/api/image",
+                    "width": 3637,
+                    "height": 2749,
+                    "tiles": [
+                      {
+                        "width": 256,
+                        "height": 256,
+                        "scaleFactors": [
+                          1,
+                          2,
+                          4,
+                          8,
+                          16
+                        ]
+                      }
+                    ],
+                    "sizes": [
+                      {
+                        "width": 1024,
+                        "height": 774
+                      },
+                      {
+                        "width": 400,
+                        "height": 302
+                      },
+                      {
+                        "width": 200,
+                        "height": 151
+                      },
+                      {
+                        "width": 100,
+                        "height": 76
+                      }
+                    ],
+                    "profile": [
+                      "http://iiif.io/api/image/2/level1.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "native",
+                          "color",
+                          "gray"
+                        ],
+                        "supports": [
+                          "regionByPct",
+                          "sizeByForcedWh",
+                          "sizeByWh",
+                          "sizeAboveFull",
+                          "rotationBy90s",
+                          "mirroring",
+                          "gray"
+                        ]
+                      }
+                    ]
+                  }
+                },
+                "selector": {
+                  "@context": "http://iiif.io/api/annex/openannotation/context.json",
+                  "type": "iiif:ImageApiSelector",
+                  "region": "559,0,2666,2749"
+                }
+              },
+              "thumbnail": [
+                {
+                  "id": "https://dlc.services/thumbs/7/21/e16c7a6b-9672-d551-70d7-08c88609efb1/full/full/0/default.jpg",
+                  "type": "Image",
+                  "service": {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/thumbs/7/21/e16c7a6b-9672-d551-70d7-08c88609efb1",
+                    "protocol": "http://iiif.io/api/image",
+                    "profile": [
+                      "http://iiif.io/api/image/2/level0.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "color"
+                        ],
+                        "supports": [
+                          "sizeByWhListed"
+                        ]
+                      }
+                    ],
+                    "width": 1024,
+                    "height": 774,
+                    "sizes": [
+                      {
+                        "width": 100,
+                        "height": 76
+                      },
+                      {
+                        "width": 200,
+                        "height": 151
+                      },
+                      {
+                        "width": 400,
+                        "height": 302
+                      },
+                      {
+                        "width": 1024,
+                        "height": 774
+                      }
+                    ]
+                  }
+                }
+              ],
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/1a5e682f-f7fc-f089-a448-91cd572b7a77",
+              "target": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/2e68af88-2b63-6c45-f4e3-6e2d3fdfa35d#xywh=0,0,2666,2749",
+              "label": {
+                "nl": [
+                  "De enige vrouw in de collegezaal (Introductieweek 1965)"
+                ],
+                "en": [
+                  "The only woman in the lecture hal (Orientation Week 1965)"
+                ]
+              },
+              "summary": {
+                "nl": [
+                  "TU Delft Library, Bijzondere Collecties"
+                ],
+                "en": [
+                  "TU Delft Library, Special Collections"
+                ]
+              }
+            }
+          ],
+          "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/list/705cb49b-41f4-492b-8a4c-0347efc4ba0d"
+        }
+      ],
+      "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/2e68af88-2b63-6c45-f4e3-6e2d3fdfa35d",
+      "behavior": [
+        "w-8",
+        "h-8"
+      ],
+      "annotations": [
+        {
+          "type": "AnnotationPage",
+          "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/2e68af88-2b63-6c45-f4e3-6e2d3fdfa35d/annotations",
+          "items": [
+            {
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/2e68af88-2b63-6c45-f4e3-6e2d3fdfa35d/annotations/97",
+              "type": "Annotation",
+              "motivation": "describing",
+              "target": {
+                "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/1a5e682f-f7fc-f089-a448-91cd572b7a77",
+                "type": "Annotation"
+              }
+            },
+            {
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/2e68af88-2b63-6c45-f4e3-6e2d3fdfa35d/annotations/98",
+              "type": "Annotation",
+              "motivation": "describing",
+              "target": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/2e68af88-2b63-6c45-f4e3-6e2d3fdfa35d#xywh=2194,860,400,400",
+              "body": [
+                {
+                  "type": "TextualBody",
+                  "value": "<h1>De enige vrouw in de collegezaal (Introductieweek 1965)</h1>\n\n<p>TU Delft Library, Bijzondere Collecties</p>",
+                  "format": "text/html",
+                  "language": "nl",
+                  "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/79fec593-1bc9-3275-8b53-7fce7790ee8b/desc/nl"
+                },
+                {
+                  "type": "TextualBody",
+                  "value": "<h1>The only woman in the lecture hal (Orientation Week 1965)</h1>\n\n<p>TU Delft Library, Special Collections</p>",
+                  "format": "text/html",
+                  "language": "en",
+                  "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/79fec593-1bc9-3275-8b53-7fce7790ee8b/desc/en"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "height": 1000,
+      "width": 1000,
+      "type": "Canvas",
+      "items": [
+        {
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "type": "Annotation",
+              "body": [
+                {
+                  "type": "TextualBody",
+                  "value": "<h1>Introductie</h1>\n\n<p>Nieuwe leden van de Delftste Vrouwelijke Studentenvereniging (DVSV) werden in het verleden ‘novieten’ genoemd, tegenover de gebruikelijke term ‘feuten’ voor mannen. Maar anders dan hun mannelijke medestudenten, die na het eerste jaar werden opgenomen in een robuuste mannengemeenschap, werden de vrouwen als minderheid ‘beleefd genegeerd’ en geacht zich eerst maar eens te bewijzen. Hoe zijn vrouwen in het verleden omgegaan met hun minderheidsrol?</p>",
+                  "format": "text/html",
+                  "language": "nl",
+                  "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/textualbody/ab31e034-8bb1-12bf-1c7b-2f9272ddddc2/nl"
+                },
+                {
+                  "type": "TextualBody",
+                  "value": "<h1>Introduction</h1>\n\n<p>In the past, new members of the 'Delftste Vrouwelijke Studentenvereniging' (DVSV – Delft student society for women) were called ‘novieten’ (‘novices’) as opposed to ‘feuten’ (with the connotation of ‘foetuses’), the term used for their male counterparts. After the first year, male students were welcomed into a robust community of men. Women, on the other hand, were a minority group. They were ‘politely ignored’ and expected to first prove themselves worthy. In the past, how did women deal with their role as a minority group?</p>",
+                  "format": "text/html",
+                  "language": "en",
+                  "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/textualbody/ab31e034-8bb1-12bf-1c7b-2f9272ddddc2/en"
+                }
+              ],
+              "target": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/d5040e5c-1e59-1da8-058d-aad3bb7e0e49",
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/497d8d8c-f07e-dd1c-8655-d3fe783c2b31",
+              "motivation": "painting"
+            }
+          ],
+          "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/list/8bfe4657-bfc5-26ba-ae16-c349fc9266eb"
+        }
+      ],
+      "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/d5040e5c-1e59-1da8-058d-aad3bb7e0e49",
+      "behavior": [
+        "info",
+        "w-4",
+        "h-4"
+      ],
+      "annotations": [
+        {
+          "type": "AnnotationPage",
+          "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/d5040e5c-1e59-1da8-058d-aad3bb7e0e49/annotations",
+          "items": [
+            {
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/d5040e5c-1e59-1da8-058d-aad3bb7e0e49/annotations/0",
+              "type": "Annotation",
+              "motivation": "describing",
+              "target": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/d5040e5c-1e59-1da8-058d-aad3bb7e0e49",
+              "body": [
+                {
+                  "type": "TextualBody",
+                  "value": "<h1>Novieten</h1>\n\n<p>Nieuwe leden van de Delftste Vrouwelijke Studentenvereniging (DVSV) werden in het verleden ‘novieten’ genoemd, tegenover de gebruikelijke term ‘feuten’ voor mannen. Maar anders dan hun mannelijke medestudenten, die na het eerste jaar werden opgenomen in een robuuste mannengemeenschap, werden de vrouwen ‘beleefd genegeerd’ en geacht zich eerst maar eens te bewijzen.</p><p>Ondanks dat in 2018 – het laatste jaar waarover de TU Delft statistische data heeft gepubliceerd – de studentenpopulaties van de studies Bouwkunde en Industrieel Ontwerpen uit een gelijk aandeel mannen en vrouwen bestaan, is het percentage vrouwelijke eerstejaars studenten aan de TU Delft over het geheel genomen nog altijd niet hoger dan 30%. Hoe heeft dit zich in de loop der tijd ontwikkeld en hoe zijn vrouwen in het verleden omgegaan met hun minderheidsrol?</p><p>Deze digitale tentoonstelling begint met een nieuwe grafiek die een overzicht geeft van het aantal en het percentage vrouwelijke eerstejaars in de periode 1905-2018. Als startdatum is 1905 gekozen omdat in dat jaar de Polytechnische School werd omgevormd tot Technische Hogeschool, waarmee vrouwen voltijds in Delft konden gaan studeren. De grafiek laat geen lineair proces zien, maar een dynamisch proces met pieken en dalen. Aan de hand van de grafiek ontvouwen zich een aantal verhalen.</p><p>Allereerst over de DVSV, opgericht in 1904, waarin vrouwelijke studenten zich verenigden en ontplooiden, grotendeels zonder een overkoepelend emancipatorisch programma. De speeches van presidentes aan de novieten laten zien hoe ‘meisjes-studenten’ zich geacht werden te gedragen binnen de universitaire gemeenschap: \"val vooral niet te veel op,\" was het voornaamste devies vóór de Tweede Wereldoorlog.</p><p>Van het relatief hoge aandeel vrouwen in de vooroorlogse jaren, wordt Antonia Korvezee uitgelicht, die in 1954 werd aangesteld als eerste vrouwelijke hoogleraar van de Technische Hogeschool. Korvezee, in Delft opgeleid en in Delft gepromoveerd, werkte begin jaren dertig enige jaren in Parijs bij madame Curie aan het toen nieuwe specialisme van radioactiviteit. Deze kennis gebruikte ze later als hoogleraar om het vakgebied in Nederland op de kaart te zetten.</p><p>Het verhaal over de DVSV loopt door na de Tweede Wereldoorlog: Marian Geense schreef een boek over de levensloop van de vrouwen uit haar jaarclub uit 1956. Deze tentoonstelling bevat een voorpublicatie. Ook wordt een recente publicatie uitgelicht over een nog steeds bestaand vrouwenhuis in de Delftse binnenstad: de Boterbrug, opgericht in 1969. Een interview met één van de oprichtsters van het huis is hier opnieuw gepubliceerd.</p><p>Tevens uit de jaren zestig stamt de fictieve documentaire ‘Mejuffrouw, Mijne Heren’ van Mart van de Busken. De glorieuze film geeft een geweldig tijdsbeeld van de TH. De verteller is een van de 'zeldzame, tot idool verheven' vrouwelijke studentes, die als enige 'mejuffrouw' plaatsneemt tussen de mannen in de collegezaal.</p><p>Vanaf de jaren zeventig loopt zowel het absolute aantal als het relatieve percentage vrouwen op. Hiermee dient zich een nieuw tijdperk aan waarin vrouwenemancipatie een centrale rol inneemt. Voor de tentoonstelling heeft de recent afgestudeerde Noortje Weenink een interview afgenomen met Anna Vos, de oprichtster van het vak Vrouwenstudies aan de Faculteit Bouwkunde. Het gesprek laat zien hoe vrouwelijke studenten allerlei normen aan de kaak stelden die de basis vormden van hun eigen vakgebied.</p><p>Anna Vos studeerde af bij Franziska Bollerey die in 1979 werd aangesteld als tweede vrouwelijke hoogleraar aan de TH Delft, 25 jaar na Korvezee. In de jaren tachtig speelde zij in een toneelstuk tijdens een van de <em>meisjesinformatiedagen</em>, bedoeld om meer vrouwelijke studenten aan te trekken voor technische studies.</p><p>De tentoonstelling sluit af met het boek <em>Technische Universiteit, een mannenwereld</em>, uitgegeven door Studium Generale in 1989. In het boek is de blik omgedraaid en wordt prikkelend onderzocht wat het betekent om een mannengemeenschap te zijn –&nbsp;en wat ervoor nodig is om deze te veranderen.</p><p>Ondanks het toenemende aantal 'novieten' en de lange geschiedenis van vrouwelijke studenten en onderzoekers in Delft, staat de universiteit tegenwoordig nog steeds te boek als een mannengemeenschap. De thema's diversiteit en inclusiviteit staan hoog op de agenda, waarbij het al lang niet meer gaat om enkel het binaire onderscheid tussen mannen en vrouwen. De eerdere ervaringen van vrouwen die in deze tentoonstelling aan bod komen, kunnen desalniettemin handvaten aanbieden voor nieuwe generaties zodat zij (in de woorden van Anna Vos) niet telkens het wiel opnieuw hoeven uit te vinden maar kunnen voortbouwen op het werk van hun voorgangers.</p><p><em>Samengesteld door Sarah Edrisy, Jules Schoonman en Abel Streefland (Academisch Erfgoed team, TU Delft Library). Opmaak grafiek door Studio Mellegers van Dam.</em></p><p>Met dank aan:</p><ul><li>Ted Barendse (Education &amp; Student Affairs)</li><li>Margreet de Boer</li><li>Marjan van den Bos</li><li>Mart van den Busken</li><li><a href=\"https://mariangeense.nl\" rel=\"noopener noreferrer\" target=\"_blank\">Marian Geense</a></li><li>Marcel Janssen</li><li>Frida de Jong</li><li>Elizabeth Poot</li><li>Roland van Roijen (NewMedia Centre)</li><li>Anna Vos</li><li>Noortje Weenink</li><li>Charlotte van Wijk (Faculteit Bouwkunde)</li><li>Koninklijke Bibliotheek</li><li>Atria, kennisinstituut voor emancipatie en vrouwengeschiedenis</li></ul>",
+                  "format": "text/html",
+                  "language": "nl",
+                  "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/d5040e5c-1e59-1da8-058d-aad3bb7e0e49/annotations/0/nl"
+                },
+                {
+                  "type": "TextualBody",
+                  "value": "<h1>Novices</h1>\n\n<p>In the past, new members of the <em>Delftste Vrouwelijke Studentenvereniging</em> (DVSV – Delft student society for women) were called ‘<em>novieten</em>’ (‘novices’) as opposed to ‘<em>feuten</em>’ (with the connotation of ‘foetuses’), the term used for their male counterparts. After the first year, male students were welcomed into a robust community of men. Women, on the other hand, were a minority group. They were ‘politely ignored’ and expected to first prove themselves worthy.</p><p>The last year about which TU Delft published statistical data was 2018. Even though in that year an equal number of men and women were studying Architecture and Industrial Design, overall, the percentage of female first-year students at TU Delft remained below 30%. How did this develop over time and, in the past, how did women deal with their role as a minority group?</p><p>This digital exhibition starts with a graph that gives an overview of the number and percentage of female first-year students from 1905 to 2018. The year 1905 was chosen as the starting date because that was when the Polytechnic School became the 'Technische Hogeschool' (Institute of Technology) and women were able to study in Delft on a full-time basis. The graph does not show a linear progression, but rather a dynamic process with peaks and troughs. Using the graph, we can see several stories unfolding.</p><p>The first involves the DVSV, established in 1904. Female students came together and were active in this society, largely without an overarching emancipation programme. The speeches given to novices by presidents demonstrate how ‘girl students’ were expected to behave within the university community: ‘Above all, don’t stand out too much,’ was the main motto prior to WWII.</p><p>Out of a relatively high number of women in the pre-war years, the spotlight is turned on Antonia Korvezee who, in 1954, became the first female professor appointed at the Institute of Technology. Korvezee, who trained at the institute and obtained a PhD there, had worked at the famous lab of Marie Curie for some time in the early 1930s, focusing on the then new specialism of radioactivity. Later, as a professor, she used this knowledge to focus attention on that field in the Netherlands.</p><p>The story of the DVSV continues after WWII: Marian Geense wrote a book on the lives of the women who had been DVSV freshers with her in 1956. This exhibition contains a preprint version of the book. Another recent publication is featured. It tells the story of a still existing girls house in the heart of Delft: the Boterbrug, established in 1969. An interview with one of the founders of the house is reprinted here.</p><p>Mart van de Busken’s '<em>Mejuffrouw, Mijne Heren'</em> (Miss and Gentlemen) also dates back to the 1960s. This wonderful film provides a fascinating portrait of the institute at that time. The narrator is one of the ‘rare female students elevated to an icon’, the only ‘miss’ seated among all the ‘gentlemen’ in the lecture hall.</p><p>In the 1970s, both the absolute number and relative percentage of women started to increase. This marked the beginning of a new era in which women’s emancipation played a central role. For the exhibition, recent graduate Noortje Weenink interviewed Anna Vos, the founder of the Women’s Studies discipline within the Architecture Faculty. The interview reveals how female students challenged all kinds of norms that constituted the basis of their own field of study.</p><p>Anna Vos graduated under Franziska Bollerey who, in 1979, was the second female professor appointed at the Institute of Technology, 25 years after Korvezee. In the 1980s, Vos acted in a play during an information day for female students. The aim was to attract more women to enrol in technical studies.</p><p>The exhibition ends with the book '<em>Technische Universiteit, een mannenwereld'</em> (University of Technology, a Man’s World) published by Studium Generale in 1989. In this book, the perspective is reversed, and what it means to be a community of men is provocatively examined alongside what it would take to bring about change.</p><p>Despite the increasing number of 'novices' and the long tradition of female students and researchers at Delft, the university is still identified as a community of men. Diversity and inclusion are given high priority and it’s no longer just about the binary distinction between men and women. Nonetheless, the past experiences of women that are dealt with in this exhibition can serve as reference points for new generations so that – to paraphrase Anna Vos – they don’t have to keep rediscovering the wheel, but can build on the work of their predecessors.</p><p><em>Curated by Sarah Edrisy, Jules Schoonman and Abel Streefland (Academisch Erfgoed team, TU Delft Library). Graph design by Studio Mellegers van Dam.</em></p><p>With thanks to:</p><ul><li>Ted Barendse (Education &amp; Student Affairs)</li><li>Margreet de Boer</li><li>Marjan van den Bos</li><li>Mart van den Busken</li><li><a href=\"https://mariangeense.nl\" rel=\"noopener noreferrer\" target=\"_blank\">Marian Geense</a></li><li>Marcel Janssen</li><li>Frida de Jong</li><li>Elizabeth Poot</li><li>Roland van Roijen (NewMedia Centre)</li><li>Anna Vos</li><li>Noortje Weenink</li><li>Charlotte van Wijk (Faculty of Architecture and the Built Environment)</li><li>Royal Library of the Netherlands</li><li>Atria, institute on gender equality and women's history</li></ul>",
+                  "format": "text/html",
+                  "language": "en",
+                  "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/d5040e5c-1e59-1da8-058d-aad3bb7e0e49/annotations/0/en"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": {
+        "nl": [
+          "Eerstejaarsstudenten van de TH en TU Delft in de periode 1905-2018"
+        ],
+        "en": [
+          "First-year students at the Delft Institute of Technology and TU Delft in the period 1905-2018"
+        ]
+      },
+      "height": 991,
+      "width": 992,
+      "type": "Canvas",
+      "items": [
+        {
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "motivation": "painting",
+              "type": "Annotation",
+              "body": {
+                "id": "https://dlc.services/iiif-img/7/21/4d8776d3-31a9-bf36-22ad-536c39f6ba5d/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 7087,
+                "width": 7088,
+                "label": {
+                  "nl": [
+                    "-"
+                  ]
+                },
+                "service": [
+                  {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/iiif-img/7/21/4d8776d3-31a9-bf36-22ad-536c39f6ba5d",
+                    "protocol": "http://iiif.io/api/image",
+                    "width": 7088,
+                    "height": 7087,
+                    "tiles": [
+                      {
+                        "width": 256,
+                        "height": 256,
+                        "scaleFactors": [
+                          1,
+                          2,
+                          4,
+                          8,
+                          16,
+                          32
+                        ]
+                      }
+                    ],
+                    "sizes": [
+                      {
+                        "width": 1024,
+                        "height": 1024
+                      },
+                      {
+                        "width": 400,
+                        "height": 400
+                      },
+                      {
+                        "width": 200,
+                        "height": 200
+                      },
+                      {
+                        "width": 100,
+                        "height": 100
+                      }
+                    ],
+                    "profile": [
+                      "http://iiif.io/api/image/2/level1.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "native",
+                          "color",
+                          "gray"
+                        ],
+                        "supports": [
+                          "regionByPct",
+                          "sizeByForcedWh",
+                          "sizeByWh",
+                          "sizeAboveFull",
+                          "rotationBy90s",
+                          "mirroring",
+                          "gray"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              "thumbnail": [
+                {
+                  "id": "https://dlc.services/thumbs/7/21/4d8776d3-31a9-bf36-22ad-536c39f6ba5d/full/full/0/default.jpg",
+                  "type": "Image",
+                  "service": {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/thumbs/7/21/4d8776d3-31a9-bf36-22ad-536c39f6ba5d",
+                    "protocol": "http://iiif.io/api/image",
+                    "profile": [
+                      "http://iiif.io/api/image/2/level0.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "color"
+                        ],
+                        "supports": [
+                          "sizeByWhListed"
+                        ]
+                      }
+                    ],
+                    "width": 1024,
+                    "height": 1024,
+                    "sizes": [
+                      {
+                        "width": 100,
+                        "height": 100
+                      },
+                      {
+                        "width": 200,
+                        "height": 200
+                      },
+                      {
+                        "width": 400,
+                        "height": 400
+                      },
+                      {
+                        "width": 1024,
+                        "height": 1024
+                      }
+                    ]
+                  }
+                }
+              ],
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/e74ff4bb-9529-2b0a-b384-9b0b6880139c",
+              "target": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/193095ba-8eeb-9716-8f29-881b3d1ac982#xywh=0,0,992,991",
+              "label": {
+                "nl": [
+                  "Eerstejaarsstudenten van de TH en TU Delft in de periode 1905-2018"
+                ],
+                "en": [
+                  "First-year students at the Delft Institute of Technology and TU Delft in the period 1905-2018"
+                ]
+              },
+              "summary": {
+                "nl": [
+                  "Bronnen: Jaarboeken en -verslagen TH Delft, Statistisch jaarboeken TU Delft en OSIRIS"
+                ],
+                "en": [
+                  "Sources: Delft Institute of Technology Yearbooks and reports, TU Delft Statistical Yearbooks and OSIRIS"
+                ]
+              }
+            }
+          ],
+          "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/list/fa80903b-fa14-3037-1730-81258e1a8a62"
+        }
+      ],
+      "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/193095ba-8eeb-9716-8f29-881b3d1ac982",
+      "behavior": [
+        "right",
+        "w-12",
+        "h-8"
+      ],
+      "summary": {
+        "nl": [
+          "Deze grafiek toont het absolute aantal eerstejaars studenten, de verdeling tussen man en vrouw en het percentage vrouwen. Pas vanaf 1905 is het voor vrouwen mogelijk om in Delft een volledige technische studie te volgen.",
+          "Opvallend aan de grafiek is dat het percentage vrouwen vóór de Tweede Wereldoorlog hoger is dan in de periode erna. Pas in 1983 stijgt het percentage weer uit boven de 11%, het maximum uit de vooroorlogse jaren.",
+          "In de loop der tijd is de definitie van eerstejaars studenten veranderd. Tot 1982 wordt er in de statistieken geen onderscheid gemaakt tussen verschillende soorten eerstejaars. Vanaf 1982 zijn de aantallen eerstejaars gebruikt inclusief 'interne omzwaaiers' (studenten die van studie wisselen), omdat deze het best overeenkwamen met de eerdere gegevens. Ook de invoering van de bachelor-masterstructuur in 2002 heeft impact gehad op de wijze van tellen, wat waarschijnlijk de 'dip' in de grafiek verklaart rond dat jaar."
+        ],
+        "en": [
+          "This graph shows the absolute number of first-year students, the distribution of men and women, and the percentage of women. It was only possible for women to follow a full-time technical study at Delft from 1905.",
+          "A striking aspect of the graph is that the percentage of women before WWII was higher than in the period that followed. The percentage only increases to more than 11% – the highest pre-war percentage – in 1983.",
+          "Over the course of time, the definition of first-year students changed. Up until 1982, no statistical distinction was made between different types of first-year students. From 1982, the numbers given for first-year students include 'internal switchers' (students who changed to a different study) because these figures were best in line with earlier data. The introduction of the bachelor’s-master’s system in 2002 also had an impact on the calculation method which probably explains the ‘dip' the graph shows in that year."
+        ]
+      },
+      "requiredStatement": {
+        "value": {
+          "nl": [
+            "Bronnen: Jaarboeken en -verslagen TH Delft, Statistisch jaarboeken TU Delft en OSIRIS"
+          ],
+          "en": [
+            "Sources: Delft Institute of Technology Yearbooks and reports, TU Delft Statistical Yearbooks and OSIRIS"
+          ]
+        }
+      },
+      "annotations": [
+        {
+          "type": "AnnotationPage",
+          "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/193095ba-8eeb-9716-8f29-881b3d1ac982/annotations",
+          "items": [
+            {
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/193095ba-8eeb-9716-8f29-881b3d1ac982/annotations/99",
+              "type": "Annotation",
+              "motivation": "describing",
+              "target": {
+                "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/e74ff4bb-9529-2b0a-b384-9b0b6880139c",
+                "type": "Annotation"
+              }
+            },
+            {
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/193095ba-8eeb-9716-8f29-881b3d1ac982/annotations/100",
+              "type": "Annotation",
+              "motivation": "describing",
+              "target": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/193095ba-8eeb-9716-8f29-881b3d1ac982#xywh=49,567,327,330",
+              "body": [
+                {
+                  "type": "TextualBody",
+                  "value": "<h1>Voor de Tweede Wereldoorlog</h1>\n\n<p>Opvallend aan de grafiek is dat het percentage vrouwen vóór de Tweede Wereldoorlog hoger is dan in de periode erna. Pas in 1983 stijgt het percentage weer uit boven de 11%, het maximum uit de vooroorlogse jaren.</p>",
+                  "format": "text/html",
+                  "language": "nl",
+                  "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/197b9cf0-b289-f8ac-606b-20730774a7a0/desc/nl"
+                },
+                {
+                  "type": "TextualBody",
+                  "value": "<h1>Before the Second World War</h1>\n\n<p>A striking aspect of the graph is that the percentage of women before WWII was higher than in the period that followed. The percentage only increases to more than 11% – the highest pre-war percentage – in 1983.</p>",
+                  "format": "text/html",
+                  "language": "en",
+                  "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/197b9cf0-b289-f8ac-606b-20730774a7a0/desc/en"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": {
+        "nl": [
+          "'Weest geen preutsch juffertje'"
+        ],
+        "en": [
+          "'Don’t be a prudish little miss'"
+        ]
+      },
+      "height": 762,
+      "width": 999,
+      "type": "Canvas",
+      "items": [
+        {
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "motivation": "painting",
+              "type": "Annotation",
+              "body": {
+                "id": "https://dlc.services/iiif-img/7/6/26266921-71ad-4692-aa85-3257b2d5d036/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 2301,
+                "width": 1640,
+                "label": {
+                  "nl": [
+                    "-"
+                  ]
+                },
+                "service": [
+                  {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/iiif-img/7/6/26266921-71ad-4692-aa85-3257b2d5d036",
+                    "protocol": "http://iiif.io/api/image",
+                    "width": 1640,
+                    "height": 2301,
+                    "tiles": [
+                      {
+                        "width": 256,
+                        "height": 256,
+                        "scaleFactors": [
+                          1,
+                          2,
+                          4,
+                          8,
+                          16
+                        ]
+                      }
+                    ],
+                    "sizes": [
+                      {
+                        "width": 730,
+                        "height": 1024
+                      },
+                      {
+                        "width": 285,
+                        "height": 400
+                      },
+                      {
+                        "width": 143,
+                        "height": 200
+                      },
+                      {
+                        "width": 71,
+                        "height": 100
+                      }
+                    ],
+                    "profile": [
+                      "http://iiif.io/api/image/2/level1.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "native",
+                          "color",
+                          "gray"
+                        ],
+                        "supports": [
+                          "regionByPct",
+                          "sizeByForcedWh",
+                          "sizeByWh",
+                          "sizeAboveFull",
+                          "rotationBy90s",
+                          "mirroring",
+                          "gray"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              "thumbnail": [
+                {
+                  "id": "https://dlc.services/thumbs/7/6/26266921-71ad-4692-aa85-3257b2d5d036/full/full/0/default.jpg",
+                  "type": "Image",
+                  "service": {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/thumbs/7/6/26266921-71ad-4692-aa85-3257b2d5d036",
+                    "protocol": "http://iiif.io/api/image",
+                    "profile": [
+                      "http://iiif.io/api/image/2/level0.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "color"
+                        ],
+                        "supports": [
+                          "sizeByWhListed"
+                        ]
+                      }
+                    ],
+                    "width": 730,
+                    "height": 1024,
+                    "sizes": [
+                      {
+                        "width": 71,
+                        "height": 100
+                      },
+                      {
+                        "width": 143,
+                        "height": 200
+                      },
+                      {
+                        "width": 285,
+                        "height": 400
+                      },
+                      {
+                        "width": 730,
+                        "height": 1024
+                      }
+                    ]
+                  }
+                }
+              ],
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/0a21149f-4dc2-c711-2072-5de2f0cd68e4",
+              "target": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/0a168bd3-4104-9dfa-2c47-ac7d53506426#xywh=67,80,220,307",
+              "label": {
+                "nl": [
+                  "Toespraak tot de nieuwe leden in 1930"
+                ],
+                "en": [
+                  "Speech to the new members in 1930"
+                ]
+              },
+              "summary": {
+                "nl": [
+                  "1/2"
+                ],
+                "en": [
+                  "1/2"
+                ]
+              }
+            },
+            {
+              "motivation": "painting",
+              "type": "Annotation",
+              "body": {
+                "id": "https://dlc.services/iiif-img/7/6/1ada59a2-03da-42b6-a6aa-9f96e677b463/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 2304,
+                "width": 1662,
+                "label": {
+                  "nl": [
+                    "-"
+                  ]
+                },
+                "service": [
+                  {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/iiif-img/7/6/1ada59a2-03da-42b6-a6aa-9f96e677b463",
+                    "protocol": "http://iiif.io/api/image",
+                    "width": 1662,
+                    "height": 2304,
+                    "tiles": [
+                      {
+                        "width": 256,
+                        "height": 256,
+                        "scaleFactors": [
+                          1,
+                          2,
+                          4,
+                          8,
+                          16
+                        ]
+                      }
+                    ],
+                    "sizes": [
+                      {
+                        "width": 739,
+                        "height": 1024
+                      },
+                      {
+                        "width": 289,
+                        "height": 400
+                      },
+                      {
+                        "width": 144,
+                        "height": 200
+                      },
+                      {
+                        "width": 72,
+                        "height": 100
+                      }
+                    ],
+                    "profile": [
+                      "http://iiif.io/api/image/2/level1.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "native",
+                          "color",
+                          "gray"
+                        ],
+                        "supports": [
+                          "regionByPct",
+                          "sizeByForcedWh",
+                          "sizeByWh",
+                          "sizeAboveFull",
+                          "rotationBy90s",
+                          "mirroring",
+                          "gray"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              "thumbnail": [
+                {
+                  "id": "https://dlc.services/thumbs/7/6/1ada59a2-03da-42b6-a6aa-9f96e677b463/full/full/0/default.jpg",
+                  "type": "Image",
+                  "service": {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/thumbs/7/6/1ada59a2-03da-42b6-a6aa-9f96e677b463",
+                    "protocol": "http://iiif.io/api/image",
+                    "profile": [
+                      "http://iiif.io/api/image/2/level0.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "color"
+                        ],
+                        "supports": [
+                          "sizeByWhListed"
+                        ]
+                      }
+                    ],
+                    "width": 739,
+                    "height": 1024,
+                    "sizes": [
+                      {
+                        "width": 72,
+                        "height": 100
+                      },
+                      {
+                        "width": 144,
+                        "height": 200
+                      },
+                      {
+                        "width": 289,
+                        "height": 400
+                      },
+                      {
+                        "width": 739,
+                        "height": 1024
+                      }
+                    ]
+                  }
+                }
+              ],
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/cbd6e9a7-f9e1-d4bd-a301-25101d08431b",
+              "target": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/0a168bd3-4104-9dfa-2c47-ac7d53506426#xywh=259,58,217,299",
+              "label": {
+                "nl": [
+                  "Toespraak tot de nieuwe leden 1930"
+                ],
+                "en": [
+                  "Speech to the new members in 1930"
+                ]
+              },
+              "summary": {
+                "nl": [
+                  "2/2"
+                ],
+                "en": [
+                  "2/2"
+                ]
+              }
+            },
+            {
+              "motivation": "painting",
+              "type": "Annotation",
+              "body": {
+                "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/d61be51e-edb9-fc8e-fcb7-dc1c54eb3361/specificResource",
+                "type": "SpecificResource",
+                "source": {
+                  "id": "https://dlc.services/iiif-img/7/6/acd52dad-b8b1-4afa-9ddf-77ee85397003/full/full/0/default.jpg",
+                  "type": "Image",
+                  "format": "image/jpeg",
+                  "height": 2312,
+                  "width": 1643,
+                  "label": {
+                    "nl": [
+                      "-"
+                    ]
+                  },
+                  "service": {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/iiif-img/7/6/acd52dad-b8b1-4afa-9ddf-77ee85397003",
+                    "protocol": "http://iiif.io/api/image",
+                    "width": 1643,
+                    "height": 2312,
+                    "tiles": [
+                      {
+                        "width": 256,
+                        "height": 256,
+                        "scaleFactors": [
+                          1,
+                          2,
+                          4,
+                          8,
+                          16
+                        ]
+                      }
+                    ],
+                    "sizes": [
+                      {
+                        "width": 728,
+                        "height": 1024
+                      },
+                      {
+                        "width": 284,
+                        "height": 400
+                      },
+                      {
+                        "width": 142,
+                        "height": 200
+                      },
+                      {
+                        "width": 71,
+                        "height": 100
+                      }
+                    ],
+                    "profile": [
+                      "http://iiif.io/api/image/2/level1.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "native",
+                          "color",
+                          "gray"
+                        ],
+                        "supports": [
+                          "regionByPct",
+                          "sizeByForcedWh",
+                          "sizeByWh",
+                          "sizeAboveFull",
+                          "rotationBy90s",
+                          "mirroring",
+                          "gray"
+                        ]
+                      }
+                    ]
+                  }
+                },
+                "selector": {
+                  "@context": "http://iiif.io/api/annex/openannotation/context.json",
+                  "type": "iiif:ImageApiSelector",
+                  "region": "376,407,1042,758"
+                }
+              },
+              "thumbnail": [
+                {
+                  "id": "https://dlc.services/thumbs/7/6/acd52dad-b8b1-4afa-9ddf-77ee85397003/full/full/0/default.jpg",
+                  "type": "Image",
+                  "service": {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/thumbs/7/6/acd52dad-b8b1-4afa-9ddf-77ee85397003",
+                    "protocol": "http://iiif.io/api/image",
+                    "profile": [
+                      "http://iiif.io/api/image/2/level0.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "color"
+                        ],
+                        "supports": [
+                          "sizeByWhListed"
+                        ]
+                      }
+                    ],
+                    "width": 728,
+                    "height": 1024,
+                    "sizes": [
+                      {
+                        "width": 71,
+                        "height": 100
+                      },
+                      {
+                        "width": 142,
+                        "height": 200
+                      },
+                      {
+                        "width": 284,
+                        "height": 400
+                      },
+                      {
+                        "width": 728,
+                        "height": 1024
+                      }
+                    ]
+                  }
+                }
+              ],
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/d61be51e-edb9-fc8e-fcb7-dc1c54eb3361",
+              "target": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/0a168bd3-4104-9dfa-2c47-ac7d53506426#xywh=466,93,342,245",
+              "label": {
+                "nl": [
+                  "Bestuur der D.V.S.V. 1928-1929"
+                ],
+                "en": [
+                  "Board of D.V.S.V. 1928-1929"
+                ]
+              }
+            },
+            {
+              "motivation": "painting",
+              "type": "Annotation",
+              "body": {
+                "id": "https://dlc.services/iiif-img/7/6/f778d6f7-4ff1-467f-a81c-a2b77ece034c/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 2363,
+                "width": 1680,
+                "label": {
+                  "nl": [
+                    "-"
+                  ]
+                },
+                "service": [
+                  {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/iiif-img/7/6/f778d6f7-4ff1-467f-a81c-a2b77ece034c",
+                    "protocol": "http://iiif.io/api/image",
+                    "width": 1680,
+                    "height": 2363,
+                    "tiles": [
+                      {
+                        "width": 256,
+                        "height": 256,
+                        "scaleFactors": [
+                          1,
+                          2,
+                          4,
+                          8,
+                          16
+                        ]
+                      }
+                    ],
+                    "sizes": [
+                      {
+                        "width": 728,
+                        "height": 1024
+                      },
+                      {
+                        "width": 284,
+                        "height": 400
+                      },
+                      {
+                        "width": 142,
+                        "height": 200
+                      },
+                      {
+                        "width": 71,
+                        "height": 100
+                      }
+                    ],
+                    "profile": [
+                      "http://iiif.io/api/image/2/level1.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "native",
+                          "color",
+                          "gray"
+                        ],
+                        "supports": [
+                          "regionByPct",
+                          "sizeByForcedWh",
+                          "sizeByWh",
+                          "sizeAboveFull",
+                          "rotationBy90s",
+                          "mirroring",
+                          "gray"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              "thumbnail": [
+                {
+                  "id": "https://dlc.services/thumbs/7/6/f778d6f7-4ff1-467f-a81c-a2b77ece034c/full/full/0/default.jpg",
+                  "type": "Image",
+                  "service": {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/thumbs/7/6/f778d6f7-4ff1-467f-a81c-a2b77ece034c",
+                    "protocol": "http://iiif.io/api/image",
+                    "profile": [
+                      "http://iiif.io/api/image/2/level0.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "color"
+                        ],
+                        "supports": [
+                          "sizeByWhListed"
+                        ]
+                      }
+                    ],
+                    "width": 728,
+                    "height": 1024,
+                    "sizes": [
+                      {
+                        "width": 71,
+                        "height": 100
+                      },
+                      {
+                        "width": 142,
+                        "height": 200
+                      },
+                      {
+                        "width": 284,
+                        "height": 400
+                      },
+                      {
+                        "width": 728,
+                        "height": 1024
+                      }
+                    ]
+                  }
+                }
+              ],
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/63ba0257-0b2a-2bc7-154d-b1fc1a926cde",
+              "target": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/0a168bd3-4104-9dfa-2c47-ac7d53506426#xywh=332,386,211,294",
+              "label": {
+                "nl": [
+                  "Toespraak tot de nieuwe leden in 1931"
+                ],
+                "en": [
+                  "Speech to the new members in 1931"
+                ]
+              },
+              "summary": {
+                "nl": [
+                  "1/3"
+                ],
+                "en": [
+                  "1/3"
+                ]
+              }
+            },
+            {
+              "motivation": "painting",
+              "type": "Annotation",
+              "body": {
+                "id": "https://dlc.services/iiif-img/7/6/c28b095c-91d1-4c47-b0eb-5dfe97f5b8ea/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 2358,
+                "width": 1648,
+                "label": {
+                  "nl": [
+                    "-"
+                  ]
+                },
+                "service": [
+                  {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/iiif-img/7/6/c28b095c-91d1-4c47-b0eb-5dfe97f5b8ea",
+                    "protocol": "http://iiif.io/api/image",
+                    "width": 1648,
+                    "height": 2358,
+                    "tiles": [
+                      {
+                        "width": 256,
+                        "height": 256,
+                        "scaleFactors": [
+                          1,
+                          2,
+                          4,
+                          8,
+                          16
+                        ]
+                      }
+                    ],
+                    "sizes": [
+                      {
+                        "width": 716,
+                        "height": 1024
+                      },
+                      {
+                        "width": 280,
+                        "height": 400
+                      },
+                      {
+                        "width": 140,
+                        "height": 200
+                      },
+                      {
+                        "width": 70,
+                        "height": 100
+                      }
+                    ],
+                    "profile": [
+                      "http://iiif.io/api/image/2/level1.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "native",
+                          "color",
+                          "gray"
+                        ],
+                        "supports": [
+                          "regionByPct",
+                          "sizeByForcedWh",
+                          "sizeByWh",
+                          "sizeAboveFull",
+                          "rotationBy90s",
+                          "mirroring",
+                          "gray"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              "thumbnail": [
+                {
+                  "id": "https://dlc.services/thumbs/7/6/c28b095c-91d1-4c47-b0eb-5dfe97f5b8ea/full/full/0/default.jpg",
+                  "type": "Image",
+                  "service": {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/thumbs/7/6/c28b095c-91d1-4c47-b0eb-5dfe97f5b8ea",
+                    "protocol": "http://iiif.io/api/image",
+                    "profile": [
+                      "http://iiif.io/api/image/2/level0.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "color"
+                        ],
+                        "supports": [
+                          "sizeByWhListed"
+                        ]
+                      }
+                    ],
+                    "width": 716,
+                    "height": 1024,
+                    "sizes": [
+                      {
+                        "width": 70,
+                        "height": 100
+                      },
+                      {
+                        "width": 140,
+                        "height": 200
+                      },
+                      {
+                        "width": 280,
+                        "height": 400
+                      },
+                      {
+                        "width": 716,
+                        "height": 1024
+                      }
+                    ]
+                  }
+                }
+              ],
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/32b1ce1c-1454-fd44-88a4-8faa1a1d5842",
+              "target": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/0a168bd3-4104-9dfa-2c47-ac7d53506426#xywh=524,416,214,303",
+              "label": {
+                "nl": [
+                  "Toespraak tot de nieuwe leden in 1931"
+                ],
+                "en": [
+                  "Speech to the new members in 1931"
+                ]
+              },
+              "summary": {
+                "nl": [
+                  "2/3"
+                ],
+                "en": [
+                  "2/3"
+                ]
+              }
+            },
+            {
+              "motivation": "painting",
+              "type": "Annotation",
+              "body": {
+                "id": "https://dlc.services/iiif-img/7/6/49a2d230-4508-4020-ba89-2f216cc6f6a9/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 2365,
+                "width": 1686,
+                "label": {
+                  "nl": [
+                    "-"
+                  ]
+                },
+                "service": [
+                  {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/iiif-img/7/6/49a2d230-4508-4020-ba89-2f216cc6f6a9",
+                    "protocol": "http://iiif.io/api/image",
+                    "width": 1686,
+                    "height": 2365,
+                    "tiles": [
+                      {
+                        "width": 256,
+                        "height": 256,
+                        "scaleFactors": [
+                          1,
+                          2,
+                          4,
+                          8,
+                          16
+                        ]
+                      }
+                    ],
+                    "sizes": [
+                      {
+                        "width": 730,
+                        "height": 1024
+                      },
+                      {
+                        "width": 285,
+                        "height": 400
+                      },
+                      {
+                        "width": 143,
+                        "height": 200
+                      },
+                      {
+                        "width": 71,
+                        "height": 100
+                      }
+                    ],
+                    "profile": [
+                      "http://iiif.io/api/image/2/level1.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "native",
+                          "color",
+                          "gray"
+                        ],
+                        "supports": [
+                          "regionByPct",
+                          "sizeByForcedWh",
+                          "sizeByWh",
+                          "sizeAboveFull",
+                          "rotationBy90s",
+                          "mirroring",
+                          "gray"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              "thumbnail": [
+                {
+                  "id": "https://dlc.services/thumbs/7/6/49a2d230-4508-4020-ba89-2f216cc6f6a9/full/full/0/default.jpg",
+                  "type": "Image",
+                  "service": {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/thumbs/7/6/49a2d230-4508-4020-ba89-2f216cc6f6a9",
+                    "protocol": "http://iiif.io/api/image",
+                    "profile": [
+                      "http://iiif.io/api/image/2/level0.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "color"
+                        ],
+                        "supports": [
+                          "sizeByWhListed"
+                        ]
+                      }
+                    ],
+                    "width": 730,
+                    "height": 1024,
+                    "sizes": [
+                      {
+                        "width": 71,
+                        "height": 100
+                      },
+                      {
+                        "width": 143,
+                        "height": 200
+                      },
+                      {
+                        "width": 285,
+                        "height": 400
+                      },
+                      {
+                        "width": 730,
+                        "height": 1024
+                      }
+                    ]
+                  }
+                }
+              ],
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/24e929ee-9902-e397-88f2-400352c29689",
+              "target": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/0a168bd3-4104-9dfa-2c47-ac7d53506426#xywh=719,396,211,294",
+              "label": {
+                "nl": [
+                  "Toespraak tot de nieuwe leden in 1931"
+                ],
+                "en": [
+                  "Speech to the new members in 1931"
+                ]
+              },
+              "summary": {
+                "nl": [
+                  "3/3"
+                ],
+                "en": [
+                  "3/3"
+                ]
+              }
+            },
+            {
+              "motivation": "painting",
+              "type": "Annotation",
+              "body": {
+                "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/37a0537b-5074-55a2-a5df-a5f8a013a602/specificResource",
+                "type": "SpecificResource",
+                "source": {
+                  "id": "https://dlc.services/iiif-img/7/6/c9f44cc6-2d5f-484f-98f1-491b030d755d/full/full/0/default.jpg",
+                  "type": "Image",
+                  "format": "image/jpeg",
+                  "height": 2362,
+                  "width": 1684,
+                  "label": {
+                    "nl": [
+                      "-"
+                    ]
+                  },
+                  "service": {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/iiif-img/7/6/c9f44cc6-2d5f-484f-98f1-491b030d755d",
+                    "protocol": "http://iiif.io/api/image",
+                    "width": 1684,
+                    "height": 2362,
+                    "tiles": [
+                      {
+                        "width": 256,
+                        "height": 256,
+                        "scaleFactors": [
+                          1,
+                          2,
+                          4,
+                          8,
+                          16
+                        ]
+                      }
+                    ],
+                    "sizes": [
+                      {
+                        "width": 730,
+                        "height": 1024
+                      },
+                      {
+                        "width": 285,
+                        "height": 400
+                      },
+                      {
+                        "width": 143,
+                        "height": 200
+                      },
+                      {
+                        "width": 71,
+                        "height": 100
+                      }
+                    ],
+                    "profile": [
+                      "http://iiif.io/api/image/2/level1.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "native",
+                          "color",
+                          "gray"
+                        ],
+                        "supports": [
+                          "regionByPct",
+                          "sizeByForcedWh",
+                          "sizeByWh",
+                          "sizeAboveFull",
+                          "rotationBy90s",
+                          "mirroring",
+                          "gray"
+                        ]
+                      }
+                    ]
+                  }
+                },
+                "selector": {
+                  "@context": "http://iiif.io/api/annex/openannotation/context.json",
+                  "type": "iiif:ImageApiSelector",
+                  "region": "377,522,1040,591"
+                }
+              },
+              "thumbnail": [
+                {
+                  "id": "https://dlc.services/thumbs/7/6/c9f44cc6-2d5f-484f-98f1-491b030d755d/full/full/0/default.jpg",
+                  "type": "Image",
+                  "service": {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/thumbs/7/6/c9f44cc6-2d5f-484f-98f1-491b030d755d",
+                    "protocol": "http://iiif.io/api/image",
+                    "profile": [
+                      "http://iiif.io/api/image/2/level0.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "color"
+                        ],
+                        "supports": [
+                          "sizeByWhListed"
+                        ]
+                      }
+                    ],
+                    "width": 730,
+                    "height": 1024,
+                    "sizes": [
+                      {
+                        "width": 71,
+                        "height": 100
+                      },
+                      {
+                        "width": 143,
+                        "height": 200
+                      },
+                      {
+                        "width": 285,
+                        "height": 400
+                      },
+                      {
+                        "width": 730,
+                        "height": 1024
+                      }
+                    ]
+                  }
+                }
+              ],
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/37a0537b-5074-55a2-a5df-a5f8a013a602",
+              "target": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/0a168bd3-4104-9dfa-2c47-ac7d53506426#xywh=48,481,299,165",
+              "label": {
+                "nl": [
+                  "Bestuur der D.V.S.V. 1929-1930"
+                ],
+                "en": [
+                  "Board of D.V.S.V. 1929-1930"
+                ]
+              }
+            }
+          ],
+          "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/list/957f3cb9-c955-0561-e37e-aa31d182c402"
+        }
+      ],
+      "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/0a168bd3-4104-9dfa-2c47-ac7d53506426",
+      "behavior": [
+        "left",
+        "w-12",
+        "h-6"
+      ],
+      "summary": {
+        "nl": [
+          "De Delftse Vrouwelijke Studentenvereniging (DVSV), opgericht in 1904, was een gezelligheidsvereniging voor vrouwelijke studenten aan de TH. Tot 1970 werden vrijwel alle vrouwelijke studenten lid. De vereniging telde in de jaren twintig ongeveer 100 leden.",
+          "In redes voor eerstejaars, afgedrukt in de almanakken, gaven de achtereenvolgende presidentes instructies aan de nieuwe leden. Tot 1940 is het belangrijkste devies: val niet op als vrouw en wees dankbaar voor de kans om in Delft te studeren. Een openlijke feministische opstelling werd afgekeurd. Pas na de Tweede Wereldoorlog zou dit geleidelijk gaan veranderen."
+        ],
+        "en": [
+          "The DVSV (Delft student society for women), established in 1904, was a social club for female students at the Institute of Technology. Up until 1970, virtually all female students were members. In the 1920s, its membership was around 100 students.",
+          "Successive society presidents gave speeches to first-year students which included instructions. These speeches were printed in yearbooks. Up until 1940, the most important motto was: don’t stand out as a woman and be grateful for the opportunity to study in Delft. Any openly feminist attitude was rejected. This would only begin to change after WWII. You can read here the speeches given in 1930 and 1931."
+        ]
+      },
+      "requiredStatement": {
+        "label": {
+          "nl": [
+            ""
+          ]
+        },
+        "value": {
+          "nl": [
+            "Lees hier de redes uit 1930 en 1931. Klik op 'Start tour' en vervolgens op 'Bekijk object' om de volledige almanakken te bekijken."
+          ],
+          "en": [
+            "Click ‘Start tour' and then 'View object' to view the complete yearbooks."
+          ]
+        }
+      },
+      "annotations": [
+        {
+          "type": "AnnotationPage",
+          "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/0a168bd3-4104-9dfa-2c47-ac7d53506426/annotations",
+          "items": [
+            {
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/0a168bd3-4104-9dfa-2c47-ac7d53506426/annotations/101",
+              "type": "Annotation",
+              "motivation": "describing",
+              "target": {
+                "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/0a21149f-4dc2-c711-2072-5de2f0cd68e4",
+                "type": "Annotation"
+              }
+            },
+            {
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/0a168bd3-4104-9dfa-2c47-ac7d53506426/annotations/102",
+              "type": "Annotation",
+              "motivation": "describing",
+              "target": {
+                "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/cbd6e9a7-f9e1-d4bd-a301-25101d08431b",
+                "type": "Annotation"
+              }
+            },
+            {
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/0a168bd3-4104-9dfa-2c47-ac7d53506426/annotations/103",
+              "type": "Annotation",
+              "motivation": "describing",
+              "target": {
+                "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/d61be51e-edb9-fc8e-fcb7-dc1c54eb3361",
+                "type": "Annotation"
+              }
+            },
+            {
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/0a168bd3-4104-9dfa-2c47-ac7d53506426/annotations/104",
+              "type": "Annotation",
+              "motivation": "describing",
+              "target": {
+                "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/63ba0257-0b2a-2bc7-154d-b1fc1a926cde",
+                "type": "Annotation"
+              }
+            },
+            {
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/0a168bd3-4104-9dfa-2c47-ac7d53506426/annotations/105",
+              "type": "Annotation",
+              "motivation": "describing",
+              "target": {
+                "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/32b1ce1c-1454-fd44-88a4-8faa1a1d5842",
+                "type": "Annotation"
+              }
+            },
+            {
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/0a168bd3-4104-9dfa-2c47-ac7d53506426/annotations/106",
+              "type": "Annotation",
+              "motivation": "describing",
+              "target": {
+                "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/24e929ee-9902-e397-88f2-400352c29689",
+                "type": "Annotation"
+              }
+            },
+            {
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/0a168bd3-4104-9dfa-2c47-ac7d53506426/annotations/107",
+              "type": "Annotation",
+              "motivation": "describing",
+              "target": {
+                "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/37a0537b-5074-55a2-a5df-a5f8a013a602",
+                "type": "Annotation"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": {
+        "nl": [
+          "Koker met promotiebul van Antonia Korvezee"
+        ],
+        "en": [
+          "Tube with the PhD award certificate of Antonia Korvezee"
+        ]
+      },
+      "height": 906,
+      "width": 1000,
+      "type": "Canvas",
+      "items": [
+        {
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "motivation": "painting",
+              "type": "Annotation",
+              "body": {
+                "id": "https://dlc.services/iiif-img/7/18/e76ce7df-b9c6-47d4-b5e0-8f1dc8fd1d51/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 1970,
+                "width": 2173,
+                "label": {
+                  "nl": [
+                    "-"
+                  ]
+                },
+                "service": [
+                  {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/iiif-img/7/18/e76ce7df-b9c6-47d4-b5e0-8f1dc8fd1d51",
+                    "protocol": "http://iiif.io/api/image",
+                    "width": 2173,
+                    "height": 1970,
+                    "tiles": [
+                      {
+                        "width": 256,
+                        "height": 256,
+                        "scaleFactors": [
+                          1,
+                          2,
+                          4,
+                          8,
+                          16
+                        ]
+                      }
+                    ],
+                    "sizes": [
+                      {
+                        "width": 1024,
+                        "height": 928
+                      },
+                      {
+                        "width": 400,
+                        "height": 363
+                      },
+                      {
+                        "width": 200,
+                        "height": 181
+                      },
+                      {
+                        "width": 100,
+                        "height": 91
+                      }
+                    ],
+                    "profile": [
+                      "http://iiif.io/api/image/2/level1.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "native",
+                          "color",
+                          "gray"
+                        ],
+                        "supports": [
+                          "regionByPct",
+                          "sizeByForcedWh",
+                          "sizeByWh",
+                          "sizeAboveFull",
+                          "rotationBy90s",
+                          "mirroring",
+                          "gray"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              "thumbnail": [
+                {
+                  "id": "https://dlc.services/thumbs/7/18/e76ce7df-b9c6-47d4-b5e0-8f1dc8fd1d51/full/full/0/default.jpg",
+                  "type": "Image",
+                  "service": {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/thumbs/7/18/e76ce7df-b9c6-47d4-b5e0-8f1dc8fd1d51",
+                    "protocol": "http://iiif.io/api/image",
+                    "profile": [
+                      "http://iiif.io/api/image/2/level0.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "color"
+                        ],
+                        "supports": [
+                          "sizeByWhListed"
+                        ]
+                      }
+                    ],
+                    "width": 1024,
+                    "height": 928,
+                    "sizes": [
+                      {
+                        "width": 100,
+                        "height": 91
+                      },
+                      {
+                        "width": 200,
+                        "height": 181
+                      },
+                      {
+                        "width": 400,
+                        "height": 363
+                      },
+                      {
+                        "width": 1024,
+                        "height": 928
+                      }
+                    ]
+                  }
+                }
+              ],
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/f47fbd93-77ad-37fc-c6ac-a1a1dbe2bdaa",
+              "target": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/f087a33b-cf1f-923f-407d-87e99fe269a1#xywh=0,0,1000,906",
+              "label": {
+                "nl": [
+                  "Koker met promotiebul van Antonia Korvezee"
+                ],
+                "en": [
+                  "Tube with the PhD award certificate of Antonia Korvezee"
+                ]
+              },
+              "summary": {
+                "nl": [
+                  "TU Delft Library, Bijzondere Collecties, 2016.0290.LIB"
+                ],
+                "en": [
+                  "TU Delft Library, Special Collections, 2016.0290.LIB"
+                ]
+              }
+            }
+          ],
+          "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/list/d81f2d55-8e04-1dba-e1f8-9fe503dbfff3"
+        }
+      ],
+      "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/f087a33b-cf1f-923f-407d-87e99fe269a1",
+      "behavior": [
+        "w-8",
+        "h-6"
+      ]
+    },
+    {
+      "height": 1000,
+      "width": 1000,
+      "type": "Canvas",
+      "items": [
+        {
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "type": "Annotation",
+              "body": [
+                {
+                  "type": "TextualBody",
+                  "value": "<h1>Prof. Dr. Ir. Antonia Korvezee</h1>\n\n<p>Antonia Korvezee (1899-1978) werd in 1954 de eerste vrouwelijke hoogleraar aan de Technische Hogeschool in Delft. Ze werd geboren in Friesland maar groeide op in Den Haag, waar ze de ‘HBS voor jongens’ doorliep.</p>\n\n<p>Vanwege haar aanleg voor wiskunde besloot ze in Delft te gaan studeren. In 1922 studeerde ze cum laude af in de scheikundige technologie en werd ze voor twee jaar assistente bij analytische scheikunde. Ze vervolgde haar opleiding in Delft door bij professor Scheffer een promotieonderzoek te doen. In 1930 promoveerde ze met lof op een onderwerp over koperchloride als katalysator.</p>\n\n<p>Van de 26 dissertaties die binnen het lab van professor Scheffer werden geschreven waren er 5 van de hand van vrouwen - voor die tijd een hoog percentage.</p>",
+                  "format": "text/html",
+                  "language": "nl",
+                  "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/textualbody/c407534f-2a77-6c10-e703-841561cbc665/nl"
+                },
+                {
+                  "type": "TextualBody",
+                  "value": "<h1>Prof. Antonia Korvezee</h1>\n\n<p>In 1954, Antonia Korvezee (1899-1978) became the first female professor at the Institute of Technology in Delft. Although born in Friesland she grew up in The Hague, where she attended the ´HBS for boys´ (former Dutch pre-university secondary school).</p>\n\n<p>Based on her aptitude for maths, she decided to study in Delft. In 1922, she graduated cum laude in Chemical Technology and worked for two years as an analytical chemistry assistant. She continued her studies in Delft by performing PhD research under Professor Scheffer. In 1930, she was awarded a PhD cum laude for her research into copper chloride as a catalyst.</p>\n\n<p>Of the 26 dissertations written in Professor Scheffer’s lab, 5 were by women – a high percentage at the time.</p>",
+                  "format": "text/html",
+                  "language": "en",
+                  "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/textualbody/c407534f-2a77-6c10-e703-841561cbc665/en"
+                }
+              ],
+              "target": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/ac93661b-0f24-170f-c8ed-e158250d2bbf",
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/990d9f5f-71ef-28b4-46af-e9e9e28c17e4",
+              "motivation": "painting"
+            }
+          ],
+          "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/list/26cadd49-5c6a-be88-fe55-14449a9cb4a3"
+        }
+      ],
+      "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/ac93661b-0f24-170f-c8ed-e158250d2bbf",
+      "behavior": [
+        "info",
+        "w-4",
+        "h-6"
+      ],
+      "annotations": [
+        {
+          "type": "AnnotationPage",
+          "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/ac93661b-0f24-170f-c8ed-e158250d2bbf/annotations",
+          "items": [
+            {
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/ac93661b-0f24-170f-c8ed-e158250d2bbf/annotations/0",
+              "type": "Annotation",
+              "motivation": "describing",
+              "target": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/ac93661b-0f24-170f-c8ed-e158250d2bbf",
+              "body": [
+                {
+                  "type": "TextualBody",
+                  "value": "<h1>Prof. Dr. Ir. Antonia Korvezee (1899-1978)</h1>\n\n<p>Antonia (Toos) Korvezee werd in 1954 de eerste vrouwelijke hoogleraar aan de Technische Hogeschool in Delft. Ze werd geboren in Friesland maar groeide op in Den Haag, waar ze de ‘HBS voor jongens’ doorliep. Vanwege haar aanleg voor wiskunde besloot ze in Delft te gaan studeren. In 1922 studeerde ze cum laude af in de scheikundige technologie en werd ze voor twee jaar assistente bij analytische scheikunde. Ze vervolgde haar opleiding in Delft door bij professor Scheffer een promotieonderzoek te doen. In 1930 promoveerde ze met lof op een onderwerp over koperchloride als katalysator. Van de 26 dissertaties die binnen het lab van professor Scheffer werden geschreven waren er 5 van de hand van vrouwen - voor die tijd een hoog percentage.</p><p>Begin jaren dertig werkte Korvezee met een toelage van het Delfts Hogeschoolfonds enige semesters in Parijs bij Irène Curie aan het toen nieuwe specialisme van radioactiviteit. Terug in Delft werd ze in 1935 privaatdocente in dit vakgebied. In status stelde dit niet veel voor, maar vaak kon dit dienen als een opstap naar een nieuw te creëren leerstoel.</p><p>Door tussenkomst van de Tweede Wereldoorlog liep het voor Korvezee echter anders. Ze vertrok uit Delft en werkte bij een bedrijf in Venlo. Na de oorlog keerde ze terug naar Delft, waar inmiddels een andere wind woei: de laboratoriumsfeer had plaatsgemaakt voor de ingenieursaanpak van de wederopbouw en het industrialisatiestreven volgens Amerikaans model. Nieuwe speerpunten waren procesindustrie, petrochemische industrie en kernenergie.</p><p>Op dat laatst gebied was Korvezee deskundige, zodat ze in 1948 werd benoemd tot lector. Bij de opvolging in 1953 van haar leermeester Scheffer werd ze echter gepasseerd en bij de voorbereiding om te komen tot een prestigieus instituut voor kernenergie-onderwijs werd ze niet betrokken. Haar taken verschoven in de richting van het onderwijs. Ze begeleide vijf promovendi, maar vestigde geen eigen school. In 1954 werd ze alsnog benoemd tot buitengewoon hoogleraar in de theoretische scheikunde. Vanaf 1959 voelde ze zich ziek en klaagde ze over ‘een alles overheersende vermoeidheid’. Haar ziekzijn noopte haar om ontslag te vragen. Haar afscheid gebeurde met stille trom. Ze overleed in Den Haag in 1978.</p><p>Opvolgsters heeft Korvezee niet gekend. Na de oorlog waren er aan de TH enkel bij de afdeling Technische Natuurkunde en bij de vakgroep Vezeltechniek nog enkel vrouwelijke collega’s werkzaam. Ondanks de grote uitbreiding van het aantal leerstoelen in de jaren vijftig en zestig duurde het 25 jaar voordat er weer een vrouw tot hoogleraar werd benoemd: Franziska Bollerey, die in 1979 hoogleraar in de architectuur- en stedenbouwgeschiedenis werd bij de afdeling Bouwkunde. In 1989 werd aan de TU een jaarlijkse emancipatieprijs ingesteld, de Antonia Korvezeeprijs, maar deze werd na enige jaren weer opgeheven.</p><p>Meer lezen: Frida de Jong, Standhouden in Delft, Gewina 20 (1997), pp. 227-243.</p>",
+                  "format": "text/html",
+                  "language": "nl",
+                  "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/ac93661b-0f24-170f-c8ed-e158250d2bbf/annotations/0/nl"
+                },
+                {
+                  "type": "TextualBody",
+                  "value": "<h1>Prof. Antonia Korvezee (1899-1978)</h1>\n\n<p>In 1954, Antonia (Toos) Korvezee (1899-1978) became the first female professor at the Institute of Technology in Delft. Although born in Friesland she grew up in The Hague, where she attended the ‘HBS (former Dutch pre-university secondary school) for boys’. Based on her aptitude for maths, she decided to study in Delft. In 1922, she graduated cum laude in chemical technology and worked for two years as an analytical chemistry assistant. She continued her studies at Delft by performing PhD research under Professor Scheffer. In 1930, she was awarded a PhD cum laude for her research into copper chloride as a catalyst. Of the 26 dissertations written in Professor Scheffer’s lab, 5 were by women – a high percentage at the time.</p><p>In the early 1930s, Korvezee received a grant from the Delft Institute of Technology Fund allowing her to work for several semesters in Paris with Irene Curie on the then new specialism of radioactivity. On her return to Delft, she became a <em>privaatdocente</em> (lecturer in a new discipline that has no professorial chair) in that discipline. Such positions had little status but often served as the first step towards the creation of a new professorial chair.</p><p>The outbreak of WWII meant that things turned out differently for Korvezee. She left Delft and went to work for a company in Venlo. She returned to Delft after the war and found a changed landscape: the laboratory approach had made way for the engineering approach of post-war reconstruction and industrialisation ambitions in line with the American model. The new focus areas included the petrochemical industry, process manufacturing and nuclear energy.</p><p>Korvezee was an expert in the latter field and was appointed a lecturer in 1948. However, she was passed over as the successor to her mentor Scheffer and she was left out of the preparations to establish a prestigious institute for nuclear energy studies. Korvezee’s duties shifted towards teaching. She supervised 5 PhD candidates, but did not establish her own school. In 1954, she became a professor by special appointment in the field of Theoretical Chemistry. She began to feel unwell in 1959 and complained about ‘an overwhelming tiredness’. Her illness forced her to submit her resignation. No ceremony marked Korvezee’s departure. She died in The Hague in 1978.</p><p>There were no successors to Korvezee. After the war, there were just a few women in the Engineering Physics and Fibre Technology departments. Despite a significant increase in the number of professorial chairs in the 1950s and ‘60s, it took 25 years for another woman to become a professor: Franziska Bollerey who, in 1979, was appointed professor of the History of Architecture and Urban Planning at the Architecture Faculty. In 1989, an annual emancipation award was introduced at TU Delft: the Antonia Korvezee Prize, but it was abandoned several years later.</p><p>Further reading: Frida de Jong, <em>Standhouden in Delft</em>, Gewina 20 (1997), pp. 227-243.</p>",
+                  "format": "text/html",
+                  "language": "en",
+                  "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/ac93661b-0f24-170f-c8ed-e158250d2bbf/annotations/0/en"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "height": 1000,
+      "width": 1000,
+      "type": "Canvas",
+      "items": [
+        {
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "type": "Annotation",
+              "body": [
+                {
+                  "type": "TextualBody",
+                  "value": "<h1>'Mijn man is geen architect; dat architectenbureau is van mij'</h1>\n\n<p>In 1956 werd de zogenoemde handelingsonbekwaamheid voor vrouwen in Nederland afgeschaft. Dit had als gevolg dat gehuwde vrouwelijke ingenieurs ook daadwerkelijk hun beroep konden gaan uitoefenen.</p>\n\n<p>In het te verschijnen boek 'Acht Vrouwen in een Mannenwereld: Van Delftsche Novieten tot Ingenieurs' beschrijft Marian Geense de levensloop van haar jaarclub van de DVSV uit 1956, en de vooroordelen waarmee de vrouwen te maken krijgen in hun werkende leven. Lees hier een voorpublicatie van het boek op basis van acht citaten.</p>",
+                  "format": "text/html",
+                  "language": "nl",
+                  "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/textualbody/cc4be6d0-482b-e2b3-2090-4ada2c8622c2/nl"
+                },
+                {
+                  "type": "TextualBody",
+                  "value": "<h1>‘My husband is not an architect – The architecture firm is mine'</h1>\n\n<p>The legal 'incapacity of women' was abolished in the Netherlands in 1956. As a result, married female engineers could actually start to practise their profession.</p>\n\n<p>In the soon to be published book 'Acht Vrouwen in een Mannenwereld: Van Delftsche Novieten tot Ingenieurs' (Eight Women in a Man’s World: From Delft Novices to Engineers)  Marian Geense describes the lives of her 1956 DVSV fellow freshers, and the prejudices women had to deal with in their profession. Here you can read a preprint version of the book based on 8 quotations.</p>",
+                  "format": "text/html",
+                  "language": "en",
+                  "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/textualbody/cc4be6d0-482b-e2b3-2090-4ada2c8622c2/en"
+                }
+              ],
+              "target": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/77947f0a-e920-99ab-8616-11f978be7778",
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/6b870481-dfa5-46b4-598b-9f6783efd563",
+              "motivation": "painting"
+            }
+          ],
+          "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/list/98ae9103-91bc-83c7-733b-e28219dcd2ec"
+        }
+      ],
+      "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/77947f0a-e920-99ab-8616-11f978be7778",
+      "behavior": [
+        "info",
+        "w-4",
+        "h-5"
+      ],
+      "annotations": [
+        {
+          "type": "AnnotationPage",
+          "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/77947f0a-e920-99ab-8616-11f978be7778/annotations",
+          "items": [
+            {
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/77947f0a-e920-99ab-8616-11f978be7778/annotations/0",
+              "type": "Annotation",
+              "motivation": "describing",
+              "target": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/77947f0a-e920-99ab-8616-11f978be7778",
+              "body": [
+                {
+                  "type": "TextualBody",
+                  "value": "<h1>Acht Vrouwen in een Mannenwereld: Van Delftsche Novieten tot Ingenieurs</h1>\n\n<p><em>Een voorpublicatie op basis van acht citaten. </em><a href=\"https://mariangeense.nl\" rel=\"noopener noreferrer\" target=\"_blank\"><em>Bezoek de website van Marian Geense</em></a><em> voor meer informatie over het boek.</em></p><h2>1. 'Ik wil ontwerpen, een stadsplan ontwikkelen dat ook daadwerkelijk gerealiseerd wordt'</h2><p>‘Ambities? Wat ben je van plan, het bevalt je toch goed als universitair docent op de TUD?’</p><p>‘Jawel.’ Hennie laat een stilte vallen om de spanning op te voeren. ‘Best leuk, hoor, dat lesgeven en projecten begeleiden, maar na een tijdje begint dat ook te vervelen. Ik ben niet voor niets stedenbouwer, ik wil de praktijk in, ik wil ontwerpen, een stadsplan ontwikkelen dat ook daadwerkelijk gerealiseerd wordt. Dus heb ik gesolliciteerd op een baan bij een stedenbouwkundig bureau.’</p><p>‘Goh, goed van je!’</p><p>‘Voor mijn veertigste, voor 1979 dus, wil ik bij een stedenbouwkundig bureau werken,’ zegt Hennie vastberaden.</p><h2>2. ‘Van een vrouw wordt verwacht dat ze haar idealen opgeeft en haar man volgt tot in de woestijn'</h2><p>Siu Ling staat op, schenkt zich koffie in. Wrevelige rimpels op haar voorhoofd. Het is toch idioot, denkt ze, dat in onze cultuur, in onze maatschappij, een man wel al zijn talenten kan ontwikkelen, zijn eerzucht kan volgen, over de hele wereld werk kan zoeken. Maar van een vrouw wordt verwacht dat ze haar idealen opgeeft en haar man volgt tot in de woestijn van een onderontwikkeld gebied. Als een vrouw kiest voor haar ambitie en haar werk wordt er schande van gesproken. Waarom zou een vrouw al haar dromen op moeten geven en mag een man de richting kiezen die hij zelf wil? Hier ben ik gelukkig, laat Folkert mij maar volgen en hier een baan zoeken.</p><h2>3. Het zal wel even wennen zijn, maar ingenieur Eygelaar is een vrouw'</h2><p>De telefoon op haar bureau rinkelt dringend.</p><p>‘Goedemorgen,’ zegt ze opgewekt. ‘Met Tineke Eygelaar.’</p><p>‘Hallo,’ klinkt het aan de andere kant van de lijn. ’Mag ik ingenieur Eygelaar van u?’’</p><p>‘Daar spreekt u mee,’ zegt ze.</p><p>‘Verbind u mij door met de ingenieur,’ klinkt het ongeduldig.</p><p>‘U bent al doorverbonden,’ zegt ze.</p><p>‘Moet u luisteren, juffrouw. Ik heb een dringende boodschap voor de ingenieur en u moet mij nu met hem doorverbinden.’</p><p>‘Daar spreekt u mee,’ herhaalt ze.</p><p>De man verliest nu echt zijn geduld.</p><p>‘Hoor eens even hier, juffrouw, ik ben niet in voor grapjes. Ik heb ingenieur Eygelaar nodig en wel nú!’</p><p>‘Ach heden.’ Ze kan haar lachen niet meer inhouden. ‘Het zal wel even wennen zijn, maar ingenieur Eygelaar is een vrouw.’</p><h2>4. 'Zo worden dictatoriale regiems gemaakt'</h2><p>De novieten leren dat er clubleden zijn en novieten, de nieuwkomers dus. De vele corveediensten zijn uiteraard voor de novieten.</p><p>‘Wat kom je hier doen?’ vraagt een clublid aan Dorothee.</p><p>‘Ik wil studeren en lid worden van de DVSV.’</p><p>‘Waarom de DVSV?’</p><p>‘Mijn moeder zei dat ik me …’</p><p>‘Moederskindjes kunnen we hier niet accepteren. Je kunt gaan.’</p><p>‘De DVSV,’ hakkelt ze, ‘is de beste studentenvereniging die er is, waardig en intellectueel en ik wil niets liever dan alles doen …’</p><p>Zo worden dictatoriale regiems gemaakt, denkt Dorothee. Maar ze schikt en plooit zich om maar in de gunst te komen, want weggestuurd worden is geen optie.</p><h2>5. ‘Meisjes hoefden niet te studeren, die kregen later toch een man'</h2><p>Maja beleeft die eerste dag van de ontgroening op OD26 op haar eigen manier. Ze denkt terug hoe de dag begon, hoe ze die ochtend werd uitgezwaaid door haar moeder, en ze realiseert zich hoe bijzonder dat is. Dat doet haar moeder anders nooit. Kennelijk vindt ze het belangrijk dat haar dochter in Delft gaat studeren.</p><p>Vanmorgen zei mama dat ze graag zag dat haar kind een carrière zou opbouwen.</p><p>‘Daar heb ik je voor grootgebracht,’ zei ze. Zij heeft zelf niet gestudeerd. Meisjes hoefden niet te studeren, die kregen later toch een man. En haar man heeft haar ook niet gestimuleerd om te studeren. Hij is immers uitvinder en hoogleraar en dat is genoeg. Mama beschouwt dat als de weeffout van haar leven.</p><h2>6. Ik ben een bèta, niks vage alfastudies'</h2><p>Ik ben een bèta, niks vage alfastudies, ik wil naar Delft, dacht Femke. Dus moet ik dat slim aanpakken als ik naar Delft wil.</p><p>En dat heeft ze doorgezet. Toen het nakomertje, haar broertje Hans, geboren werd heeft ze haar wil doorgedreven. Dit is mijn kans, dacht ze. Iedereen had het druk met dat kind en toen ze even niet opletten, is ze afgereisd naar Delft om zich in te schrijven.</p><p>‘Waar ga je naartoe?’ riep oma nog.</p><p>‘Even naar mijn vriendin, ik ben met het avondeten weer terug.’</p><p>Weg was ze.</p><p>Die ambtenaar van de Technische Hogeschool vroeg nog om een handtekening van haar vader of wettelijke vertegenwoordiger, maar dat probleem was snel opgelost. Even een straatje om, op een bankje een valse handtekening zetten en de zaak was voor elkaar. Weet die ambtenaar veel en tegen de tijd dat de rekening van het collegegeld in de brievenbus valt, ziet ze wel weer.</p><h2>7. ‘Ik begon mijn carrière met een verontrustend artikel over een dorp in Japan waar mensen ernstig ziek werden door verontreinigingen'</h2><p>'Wat wij doen is technologische kennis en hulpmiddelen introduceren in de gezondheidszorg,’ vertelt Tineke. Zij heeft zich in een ruime fauteuil genesteld en serveert thee met een koekje. ‘Wij gaan uit van de vraagstelling in de zorgsector. Voor technologische oplossingen is veel belangstelling. Verschillende buitenlandse onderzoekers komen tijdelijk bij onze vakgroep werken.’</p><p>‘Lijkt me interessant om een medisch vraagstuk te vertalen naar een elektrotechnisch probleem,’ meent Marian. Ze zit in een luie stoel naast een rommelig bijzettafeltje, waar naast krant en bril van Tineke nog een schaal met koekjes prijkt.</p><p>‘Dat is wat het boeiend maakt. Je moet buiten de grenzen van je eigen vakgebied kunnen kijken en de problemen die daar spelen vertalen naar een elektrotechnische opgaaf en daarna terugvertalen naar de medische wereld.’</p><p>‘Dat is nog eens wat anders dan een haven.’ Marian pakt een koekje en vervolgt: ‘Ik begon mijn carrière met een verontrustend artikel over een dorp in Japan waar mensen ernstig ziek werden door verontreinigingen. Sindsdien worden er steeds meer eisen gesteld om het milieu te beschermen. Als we een nieuwe haven baggeren in een natuurgebied moeten we elders nieuwe natuur creëren.’</p><h2>8. ‘Mijn man is geen architect. Dat architectenbureau is van mij'</h2><p>‘Dat zal ik u precies vertellen,’ zegt de docent. De mondhoeken van zijn pruimenmondje zakken misprijzend omlaag. ‘Als een kind thuiskomt, dan hoort daar de moeder te zijn, die haar ondersteunt en vragen kan beantwoorden en helpt bij huiswerk en problemen met vriendjes en zo. Maar Barbara heeft me verteld dat u geen van beiden thuis bent als zij uit school komt. Het is niet goed voor een kind om in een leeg huis te komen.’ Hij kijkt hen verwijtend aan, haalt zijn bril van zijn neus en begint die te poetsen om zijn woorden goed tot hen door te laten dringen.</p><p>Hetty voelt zich geroepen om ook wat te zeggen.</p><p>‘Ja, dat is het probleem met een eigen bedrijf,’ zegt ze. ‘Dan wordt er veel meer een beroep gedaan op de zelfredzaamheid van de kinderen. Maar het voordeel is wel dat kinderen hierdoor sneller onafhankelijk en zelfstandig worden.’</p><p>‘U ziet dat helemaal verkeerd.’ De docent snuift luidruchtig. ‘Ik heb uitgebreid met Barbara gesproken. Het is een bijzonder lief meisje. Ze wilde u eerst niets verwijten, maar toen kwam het hoge woord eruit. Zij verwijt u dat u nooit thuis bent en haar verwaarloost. En ik vind het mijn plicht, als klassendocent van uw dochter, om u, mevrouw, hierover aan te spreken.’ Zijn ogen priemen als een geslepen potlood in haar richting.</p><p>‘U bedoelt?’ zegt Hetty.</p><p>‘Ik bedoel dat een vrouw haar kinderen moet begeleiden en haar man moet ondersteunen. Het is de taak van een vrouw om thuis te zijn voor man en kinderen, zodat u ze goede raad kunt geven en met uw wijze woorden kunt ondersteunen. Een vrouw waakt over haar huishouding, nietsdoen is haar onbekend.’ Zelfvoldaan staart hij haar aan.</p><p>‘En wat is de taak van een man?’ vraagt Hetty, lichtelijk aangeslagen.</p><p>‘Uw man is een belangrijk architect. Hij heeft een eigen architectenbureau. Dat is een drukke en verantwoordelijke baan en hij heeft daarom geen tijd om de kinderen te begeleiden. Dat is de taak van de vrouw, van u, mevrouw.’</p><p>Er balt zich iets in Hetty samen.</p><p>‘Bedoelt u architectenbureau LG102?’ zegt ze. ‘Mijn man is geen architect. Dat architectenbureau is van mij.’</p>",
+                  "format": "text/html",
+                  "language": "nl",
+                  "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/77947f0a-e920-99ab-8616-11f978be7778/annotations/0/nl"
+                },
+                {
+                  "type": "TextualBody",
+                  "value": "<h1>Eight Women in a Man’s World: From Delft Novices to Engineers</h1>\n\n<p><em>A preprint version based on eight quotations. Visit </em><a href=\"https://mariangeense.nl\" rel=\"noopener noreferrer\" target=\"_blank\"><em>Marian Geense's website</em></a><em> for more information about the book.</em></p><h2>1. 'I want to design, develop an urban plan that will actually be built.'</h2><p>‘Ambitions? What do you intend to do, you like being a senior lecturer at TU Delft, don’t you?’</p><p>‘Yes.’ Hennie pauses and remains silent to let the tension rise. ‘It’s enjoyable, teaching and supervising projects. But after a while it also becomes boring. I became an urban planner for a reason – I want to practise my profession, I want to design, develop an urban plan that will actually be built. So, I’ve applied for a job at an urban planning firm.’</p><p>‘Wow, good for you!’</p><p>‘Before I turn forty, so before 1979, I want to be working for an urban planning firm,’ says Hennie, with determination.</p><h2>2. ‘A woman is expected to give up her dreams and follow her husband all the way into the desert.'</h2><p>Siu Ling stands up, pours a cup of coffee, her forehead wrinkled in irritation. It’s absurd, she thinks, that in our culture, in our society, a man can develop all his talents, pursue his ambitions, seek work anywhere in the world. But a woman is expected to give up her dreams and follow her husband all the way into the desert of a developing region. If a woman chooses to pursue her ambitions, it’s considered scandalous. Why does a woman have to give up all her dreams while a man can choose any path he likes? I’m happy here, let Folkert follow me instead and look for a job here.</p><h2>3. ‘It might take some getting used to, but engineer Eygelaar is a woman.'</h2><p>The telephone on her desk is ringing loudly.</p><p>‘Good morning,’ she says, cheerfully. ‘Tineke Eygelaar speaking.’</p><p>‘Hello,’ says the voice at the other end of the line. ’Can you connect me to engineer Eygelaar?’</p><p>‘Speaking,’ she says.</p><p>‘Connect me to the engineer,’ the voice sounds impatient.</p><p>‘You are connected,’ she says.</p><p>‘Listen, miss. I have an urgent message for the engineer and you have to connect me with him.’</p><p>‘You’re speaking to the engineer,’ she repeats.</p><p>The man has had enough.</p><p>‘You listen to me, miss, enough of your jokes. I need engineer Eygelaar and right now!’</p><p>‘Oh, dear me.’ She struggles to stifle her laughter. ‘It might take some getting used to, but engineer Eygelaar is a woman.’</p><h2>4. 'This is how dictatorships are created.'</h2><p>The novices learn that there are society members and novices, the newcomers. Of course, the many tedious chores were for the novices.</p><p>‘Why did you come here?’ a society member asks Dorothee.</p><p>‘I want to study and become a DVSV member.’</p><p>‘Why the DVSV?’</p><p>‘My mother said that…’</p><p>‘We don’t accept mummy’s girls here. You can leave.’</p><p>‘The DVSV,’ she stammers,‘is the best student society there is, decent and intellectual – and I want nothing more than to do everything…’</p><p>This is how dictatorships are created, Dorothee thinks. But she adjusts and plays along to gain favour because being sent away isn’t an option.</p><h2>5. ‘Girls didn’t have to study, after all they’d find a husband later.'</h2><p>Maja experienced the first day of initiation in her own way at Oude Delft 26. She thinks back to how the day started, how her mother waved her goodbye. She realises how special that was. Her mother never did that. Apparently, her mother felt it was important that her daughter was going to study in Delft.</p><p>That morning, mummy said that she’d like to see her child build a career.</p><p>‘That’s what I raised you to do,’ she says. She herself never studied. Girls didn’t have to study, after all they’d find a husband later. And her husband didn’t encourage her to study. After all, he’s an inventor and a professor and that’s more than enough. Mummy considered that to be a structural flaw in the fabric of her life.</p><h2>6. ´I’m a sciences person, I don’t care about vague humanities fields.'</h2><p>I’m a sciences person, I don’t care about vague humanities fields. I want to go to Delft, thought Femke. And that means I have to approach things in a clever way.</p><p>And she did just that. When a late addition to the family arrived, her baby brother Hans, she seized the opportunity. This is my chance, she thought. Everyone was busy with the baby and while they were distracted for a moment, she set off for Delft to enrol.</p><p>‘Where are you going?’ grandma calls out.</p><p>‘Just to see a friend, I’ll be back in time for dinner.’</p><p>And she was gone.</p><p>The official at the Institute of Technology asked for the signature of her father’s or legal representative, but that was soon fixed. A quick walk around the corner, find a bench, forge a signature and… problem solved. How could the official know? Femke would worry about the bill for tuition fees arriving when the time came.</p><h2>7. ‘My career began when I read an alarming article about a village in Japan where people were becoming seriously ill due to pollution.'</h2><p>'We introduce technological knowledge and tools into the healthcare sector,’ explains Tineke, nestled in a large armchair, serving tea biscuits. ‘Our starting point is the context of the healthcare sector. There is a lot of interest in technological solutions. Various researchers from other countries come to our department to work for a time.’</p><p>‘It strikes me as interesting to translate a medical issue into an electrical engineering problem,’ says Marian. She’s sitting in an easy chair next to a cluttered side table where a plate of biscuits sits alongside a newspaper and Tineke’s glasses.</p><p>‘That’s what makes it exciting. You have to go beyond the boundaries of your own discipline and translate the problems you find there into a well-reasoned electrical engineering solution, and then translate it back into the medical situation.’</p><p>‘That’s something quite different to a port.’ Marian takes a biscuit and continues, ‘My career began when I read an alarming article about a village in Japan where people were becoming seriously ill due to pollution. Since then, increasingly more requirements are being set with the aim of protecting the environment. When we dredge a new port in a wildlife area, we have to create just such an area somewhere else.’</p><h2>8. ‘My husband is not an architect – the architecture firm is mine.'</h2><p>‘I’ll explain it to you in full,’ says the teacher, the corners of his small prim mouth turned down disdainfully. ‘A mother should be at home when her child comes home from school. A mother provides support, answers questions, helps with homework and any problems with friends and the like. But Barbara tells me that neither one of you is home when she gets back from school. It’s not good for a child to return to an empty house.’ He stares at them accusingly, removes his glasses and starts to polish the lenses to let his words have their full impact.</p><p>Hetty feels obliged to respond.</p><p>‘Yes, that’s the problem with running your own business,’ she says. ‘You have to call on the self-reliance of children much more. But the upside is that as a result, children become independent more quickly.’</p><p>‘You’re looking at it in completely the wrong way.’ The teacher sniffs loudly. ‘I have spoken extensively with Barbara. She is a particularly sweet girl. She didn’t want to blame you at first, but then the truth came out. She blames you for never being home and for neglecting her. And it’s my duty as your daughter’s class teacher to address this matter with you, madam.’ His piercing eyes focus on her like sharpened pencils.</p><p>‘What do you mean?’ asks Hetty.</p><p>‘I mean that a woman is meant to take care of her children and support her husband. A woman’s duty is to stay at home for her husband and children so that she can give sound advice and support her family with wise words. A woman protects her household. She doesn’t know what doing nothing means.’ He glares at her, brimming with self-satisfaction.</p><p>‘And what is a husband’s duty?’ asks Hetty, somewhat distraught.</p><p>‘Your husband is a major architect. He has his own architecture firm. That is a high-pressure job with a lot of responsibility and that’s why he has no time to take care of the children. That duty is yours, madam, as his wife.’</p><p>Something is going on inside Hetty.</p><p>‘You’re talking about the architecture firm LG102?’ she asks. ‘My husband is not an architect – the architecture firm is mine.’</p>",
+                  "format": "text/html",
+                  "language": "en",
+                  "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/77947f0a-e920-99ab-8616-11f978be7778/annotations/0/en"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": {
+        "nl": [
+          "De Club van de DVSV"
+        ],
+        "en": [
+          "The DVSV Club (circa 1956)"
+        ]
+      },
+      "height": 656,
+      "width": 1000,
+      "type": "Canvas",
+      "items": [
+        {
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "motivation": "painting",
+              "type": "Annotation",
+              "body": {
+                "id": "https://dlc.services/iiif-img/7/21/59cbd665-a7b3-5f8a-2c16-f406ca74f5fb/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 2950,
+                "width": 4492,
+                "label": {
+                  "nl": [
+                    "-"
+                  ]
+                },
+                "service": [
+                  {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/iiif-img/7/21/59cbd665-a7b3-5f8a-2c16-f406ca74f5fb",
+                    "protocol": "http://iiif.io/api/image",
+                    "width": 4492,
+                    "height": 2950,
+                    "tiles": [
+                      {
+                        "width": 256,
+                        "height": 256,
+                        "scaleFactors": [
+                          1,
+                          2,
+                          4,
+                          8,
+                          16,
+                          32
+                        ]
+                      }
+                    ],
+                    "sizes": [
+                      {
+                        "width": 1024,
+                        "height": 672
+                      },
+                      {
+                        "width": 400,
+                        "height": 263
+                      },
+                      {
+                        "width": 200,
+                        "height": 131
+                      },
+                      {
+                        "width": 100,
+                        "height": 66
+                      }
+                    ],
+                    "profile": [
+                      "http://iiif.io/api/image/2/level1.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "native",
+                          "color",
+                          "gray"
+                        ],
+                        "supports": [
+                          "regionByPct",
+                          "sizeByForcedWh",
+                          "sizeByWh",
+                          "sizeAboveFull",
+                          "rotationBy90s",
+                          "mirroring",
+                          "gray"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              "thumbnail": [
+                {
+                  "id": "https://dlc.services/thumbs/7/21/59cbd665-a7b3-5f8a-2c16-f406ca74f5fb/full/full/0/default.jpg",
+                  "type": "Image",
+                  "service": {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/thumbs/7/21/59cbd665-a7b3-5f8a-2c16-f406ca74f5fb",
+                    "protocol": "http://iiif.io/api/image",
+                    "profile": [
+                      "http://iiif.io/api/image/2/level0.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "color"
+                        ],
+                        "supports": [
+                          "sizeByWhListed"
+                        ]
+                      }
+                    ],
+                    "width": 1024,
+                    "height": 672,
+                    "sizes": [
+                      {
+                        "width": 100,
+                        "height": 66
+                      },
+                      {
+                        "width": 200,
+                        "height": 131
+                      },
+                      {
+                        "width": 400,
+                        "height": 263
+                      },
+                      {
+                        "width": 1024,
+                        "height": 672
+                      }
+                    ]
+                  }
+                }
+              ],
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/bd1cee2a-2711-286e-85c0-e59fba3b4487",
+              "target": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/6118e9ac-0aff-f5cb-47dd-5b9a2f8715ac#xywh=0,0,1000,656",
+              "summary": {
+                "nl": [
+                  "Eerstejaars Bouwkunde-studenten brengen het hout voor de open haard naar de opslag in de kelder. De Club bevond zich op de Oude Delft 26; links op de foto de beheerder van het pand."
+                ],
+                "en": [
+                  "First-year Architecture students carrying wood for the fireplace to the storage area in the cellar. The Club is on Oude Delft 26; the manager of the building is on the left of the photo."
+                ]
+              },
+              "label": {
+                "nl": [
+                  "De Club van de DVSV (Rond 1956)"
+                ],
+                "en": [
+                  "The DVSV Club (circa 1956)"
+                ]
+              }
+            }
+          ],
+          "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/list/106f7d77-fa57-f509-b2ec-df6624c49528"
+        }
+      ],
+      "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/6118e9ac-0aff-f5cb-47dd-5b9a2f8715ac",
+      "behavior": [
+        "left",
+        "w-8",
+        "h-5"
+      ]
+    },
+    {
+      "label": {
+        "nl": [
+          "Mejuffrouw, Mijne Heren (1964)"
+        ],
+        "en": [
+          "Mejuffrouw, Mijne Heren (Miss and Gentlemen, 1964)"
+        ]
+      },
+      "height": 1440,
+      "width": 1903,
+      "type": "Canvas",
+      "items": [
+        {
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "type": "Annotation",
+              "body": [
+                {
+                  "id": "https://www.youtube.com/watch?v=popa6e9Sv5E",
+                  "type": "Video",
+                  "service": [
+                    {
+                      "profile": "http://digirati.com/objectifier",
+                      "params": {
+                        "data": "https://www.youtube.com/embed/popa6e9Sv5E?start=89"
+                      }
+                    },
+                    {
+                      "id": "https://www.youtube.com/watch?v=popa6e9Sv5E",
+                      "profile": "https://www.youtube.com",
+                      "start": 89
+                    }
+                  ]
+                }
+              ],
+              "target": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/2a2810e5-ad56-fac9-029a-d0c9fc038c1c#xywh=0,0,1903,1440",
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/6179e7da-69e0-00bb-f87d-14d8c9790be1",
+              "motivation": "painting",
+              "thumbnail": [
+                {
+                  "id": "https://dlc.services/thumbs/7/21/5ee8ead6-8cdb-5062-b9b4-dd9f0c2dc956/full/full/0/default.jpg"
+                }
+              ],
+              "label": {
+                "nl": [
+                  "Mejuffrouw, Mijne Heren (1964)"
+                ],
+                "en": [
+                  "Mejuffrouw, Mijne Heren (Miss and Gentlemen, 1964)"
+                ]
+              },
+              "summary": {
+                "nl": [
+                  "Fictieve documentaire van Mart van den Busken over het Delftse studentenleven in de jaren zestig. Verhaald door een van de weinige vrouwelijke studenten."
+                ],
+                "en": [
+                  "Mart van den Busken’s film about student life in Delft in the 1960s. Narrated by one of the few female students."
+                ]
+              }
+            }
+          ],
+          "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/list/ad7c99c7-3b50-0c0a-e914-ea90750043db"
+        }
+      ],
+      "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/2a2810e5-ad56-fac9-029a-d0c9fc038c1c",
+      "behavior": [
+        "w-12",
+        "h-9"
+      ]
+    },
+    {
+      "height": 1000,
+      "width": 1000,
+      "type": "Canvas",
+      "items": [
+        {
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "type": "Annotation",
+              "body": [
+                {
+                  "type": "TextualBody",
+                  "value": "<h1>'Over seks werd niet gesproken'</h1>\n\n<p>In 1969 werd Boterbrug 5 opgericht, een meisjeshuis van de DVSV. 10 jaar later verhuisden de bewoners naar de Oude Delft 100, maar bleef de naam Boterbrug behouden. Na de fusie van de DVSV met het Delftsch Studenten Corps in 1976 en de recente aankoop van het pand op de Oude Delft, is de Boterburg tegenwoordig een 'Corpshuis' voor vrouwen.</p>\n\n<p>Ter gelegenheid van het 50-jarig bestaan van de Boterbrug in 2019 is een jubileumboek gemaakt met daarin interviews met álle 75 bewoners, van 1969 tot nu. Lees hier een interview met Margreet de Boer, één van de oprichters van het huis.</p>",
+                  "format": "text/html",
+                  "language": "nl",
+                  "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/textualbody/7750930a-6f66-dabb-1c69-0522476183d7/nl"
+                },
+                {
+                  "type": "TextualBody",
+                  "value": "<h1>'Sex wasn’t talked about'</h1>\n\n<p>Boterbrug 5, one of DVSV’s girls houses, was established in 1969. 10 years later, the residents relocated to Oude Delft 100, but they kept the name Boterbrug. Following the merger of the DVSV and the Delftsch Studenten Corps (student society for male students) in 1976 and the recent purchase of the building on Oude Delft, today, the Boterburg is a 'Corpshuis' for women.</p>\n\n<p>In 2019, on the occasion of the 50th anniversary of the Boterbrug, a book was produced containing interviews with all 75 residents, from 1969 to today. Here, you can read an interview with Margreet de Boer, one of the founders of the house.</p>",
+                  "format": "text/html",
+                  "language": "en",
+                  "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/textualbody/7750930a-6f66-dabb-1c69-0522476183d7/en"
+                }
+              ],
+              "target": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/c7f195ab-93ef-5bad-d356-a8a84acf4667",
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/39fdfd31-1d8f-78ff-fc4f-8052be27ca4e",
+              "motivation": "painting"
+            }
+          ],
+          "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/list/27b7bb54-08f4-c26a-0a79-8f16276466a0"
+        }
+      ],
+      "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/c7f195ab-93ef-5bad-d356-a8a84acf4667",
+      "behavior": [
+        "info",
+        "w-6",
+        "h-4"
+      ],
+      "annotations": [
+        {
+          "type": "AnnotationPage",
+          "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/c7f195ab-93ef-5bad-d356-a8a84acf4667/annotations",
+          "items": [
+            {
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/c7f195ab-93ef-5bad-d356-a8a84acf4667/annotations/0",
+              "type": "Annotation",
+              "motivation": "describing",
+              "target": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/c7f195ab-93ef-5bad-d356-a8a84acf4667",
+              "body": [
+                {
+                  "type": "TextualBody",
+                  "value": "<h1>In gesprek met Margreet de Boer</h1>\n\n<p><em>Interview door Sacha Klinkhamer. Uit: Marjan van den Bos en Bab Rentjes (red.) De Boterbabes (2019). Uitgegeven in eigen beheer.</em></p><p><strong>Samen met Babs Rentjes stond Margreet als oprichter aan de wieg van de Boterbrug. Ze hebben, om zo te zeggen, samen ruim 70 kinderen gekregen. Tijd voor een terugblik. Als de voordeur opengaat van haar pied-a-terre in Den Haag, sta je meteen in een wervelwind van kleuren. Op de muren, de meubels, op de vloer. Gelukkig is Margreet een heel rustige vrouw, en door haar lage stem klinkt alles wat ze zegt kalm en zelfverzekerd. Maar zo zelfverzekerd blijkt ze niet te zijn. Haar leven is haar overkomen, bewuste keuzes waren het vaak niet. Wel had ze van huis meegekregen dat vrouwen vanzelfsprekend werkten, want haar vader en moeder waren samen de oprichters van een tuinbouwschool voor biologische landbouw. In 1946! Later ontwierp zij zowel architectuur als landschap en tuininrichting. Nee, geen plantjes, Margreet is van de structuur. Ook gaf ze, als het zo uitkwam, cursussen aan huisvrouwen in vrouwenadviescommissies, dames die moesten leren tekeningen lezen, maar wél al heel goed wisten dat er in elke woning een flink verhuisraam moet zitten. Ze had altijd wel werk, dat moest ook wel na haar scheiding en met drie kinderen. Nu is ze voor de derde keer getrouwd, met een Tsjechisch architect en professor. Ze kijkt tevreden terug op het huislustrum in 2019. God schiep de wereld. Babs en Margreet schiepen de Boterbrugster. Naar hun gelijkenis.</strong></p><p>'Ik haatte meisjeshuizen, ik had al vijf jaar alleen gewoond. De club (OD26) vond ik vreselijk, de meisjes van de Paardenmarkt waren trutten en OD 128 waren oude dames. Babs en ik zochten zes leuke meisjes die bij ons pasten. We moesten ons bij elkaar ons gemak voelen. Ik denk dat we geen serieuze criteria hadden, we vonden gewoon dat je een soort familietje moest zijn. Diversiteit was daarbij geen doel. Het plan was om uit elk jaar iemand te hebben. Dat is compleet mislukt, de meisjes waren op één na allemaal derdejaars. We hebben een keer iemand moeten zeggen dat ze werd afgewezen. Die was psychisch niet in orde, ik vond het vreselijk. Maar uitstemmen, dat deden we niet, er kwam altijd iemand bij die paste. We waren vrij serieus, we wilden ook serieus contact en een goed gesprek hebben. Ik zat soms met de eerstejaars een hele nacht op de trap levensraadselen op te lossen. Met een fles vierkant, dat wel. De jongste en de oudste.</p><p>'Over seks werd in huis echt niet gesproken. We kregen op de DVSV wel seksuele voorlichting, toen hoorde ik voor het eerst over lesbische vrouwen. Eigenlijk is dat logisch in een vrouwenvereniging, en het werd ook best feitelijk gebracht, maar mij was het een onbekend fenomeen. Ik had vrij snel een vriend die bij mij sliep, maar we zorgden er wel voor dat we geen burengerucht veroorzaakten. We hadden eigenlijk nooit last van de vriendjes. Ze aten ook niet mee.</p><p>'Ons bijbaantje was bij het eenmansbureau van Koumans. Hij koos mij uit om zijn telefoon op te nemen en met hem te lunchen, met veel franse kaas en wijn. Ik kreeg gewoon maandgeld, vierhonderd gulden, denk ik, en aan het eind van de maand stond ik nooit rood. Ik at gewoon veel minder. Mijn vriendin was een dochter van Jamin, die at biefstuk. Ik niet. Ik kookte voor Babs en mij, we kookten om de beurt ons potje en schoven bij elkaar aan, aan de tafel in de keuken.</p><p>'Iedereen kon zichzelf zijn. Je liet elkaar vrij, er waren geen regeltjes. We hadden wel afspraken. Opruimen als je gekookt hebt. Afspreken en aanspreken, dat wel. Je hielp elkaar ook als je vastliep met het ontwerpen. Maar er was niemand die commentaar had toen ik naast Joop nog verliefd werd op een ander. Iedereen wist het, maar ze zeiden niets, heel tolerant.</p><p>'Vorige week waren we met mijn huisgenoten en wat jongere Boterbrugsters bij elkaar voor een etentje en een strandwandeling. Toen hadden we met z'n achten een avond heel openhartige, ontroerende gesprekken. Hier kan je alles zeggen wat je beweegt, hier wordt er echt naar je geluisterd en de manier waarop iemand een vraag stelde opende steeds een volgend luikje. Die openheid hadden we ook bij de Boterbrug reünies, vooral bij de speeches aan tafel. We hebben een familiegevoel, we zijn vertrouwd met elkaar. Je hoeft niet op te scheppen. Of die openheid door de jaren heen nu begon bij de eerste lustrumspeeches van Babs en mij, dat weet ik niet, het kan. In ieder geval is er nu, als we bij elkaar zijn, altijd een echt gesprek en ook heel veel emotie. Over dilemma's met je ouders, en over borstkanker. Het was echt heel bijzonder. Bij de antroposofen zeggen ze wel dat kinderen hun ouders uitzoeken en bij ons huis is dat misschien ook wel zo. Alsof het op een ander niveau is voorgekookt, dat je bij elkaar past. Het is niet expliciet, misschien is er al een band vóórdat je elkaar leert kennen, en dan herken je elkaar als je met elkaar in gesprek bent. Het is niet je huisgenoten uitkiezen, het is herkennen.</p><p>'Ook bij de jongste huisgenoten denk ik meteen: “Oooo wat heerlijk, wat leuk! We kennen elkaar!” Iemand die dertig jaar jonger was heeft mij een keer op een lustrum mee naar huis genomen toen ik teveel gedronken had. Lief, hè? We zijn pretentieloos, hoeven niet mooi te zijn of een stand op te houden, we zijn kameraden en we zijn lief voor de buren. Het zijn nu toch ook allemaal schatjes!'</p>",
+                  "format": "text/html",
+                  "language": "nl",
+                  "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/c7f195ab-93ef-5bad-d356-a8a84acf4667/annotations/0/nl"
+                },
+                {
+                  "type": "TextualBody",
+                  "value": "<h1>An interview with Margreet de Boer</h1>\n\n<p><em>Interview by Sacha Klinkhamer. Source: Marjan van den Bos and Bab Rentjes (eds.) De Boterbabes (2019). Self-published.</em></p><p><strong>As a co-founder, together with Babs Rentjes, Margreet was part of the Boterbrug from the outset. You could say that the two women gave birth to over 70 children. Time to look back. When the front door of her pied-à-terre in The Hague opens, you’re immediately met by a whirlwind of colours. On the walls, the floor and the furniture. Luckily, Margreet is a quiet woman and her low voice makes everything she says sound calm and self-assured. But she turns out not to be all that self-confident. Her life was something that happened, conscious choices were absent. She was, however, raised with the premise that it was natural for women to work because her parents had together established a horticultural school for organic agriculture – in 1946! Later, Margreet designed buildings as well as landscapes and gardens, but no plants. Margreet is all about structure. When possible, she also gave courses for housewives on women’s advisory committees, ladies who had to learn how to read drawings, but who already knew that every house had to have a large casement window. Margreet always worked – she had to, being divorced with three children. She is now married to her third husband, a Czech architect and professor. She looks back with satisfaction on the Boterbrug’s 50th anniversary in 2019. God created the world. Babs and Margreet created the Boterbrug residents. In their own image.</strong></p><p>'I hated women’s housing, I’d already lived on my own for five years. I thought the club (Oude Delft 26) was awful, the Paardenmarkt girls were cows and the Oude Delft 128 ones were like old ladies. Babs and I sought out six pleasant girls we could get along with. We had to feel comfortable with each other. I don’t think we had any serious criteria, we just thought we should be like a kind of small family. Diversity wasn’t the aim. The plan was to have someone from each year. We failed completely – all but one of the girls were in the third year. One time, we had to tell someone that she had been rejected. She was not entirely mentally stable, I felt terrible. But we never voted anyone out, the people who joined always fitted in. We were quite serious, we also wanted serious interactions and to have good discussions. Sometimes, I would sit all night on the stairs with first-year students solving life’s problems. Needless to say, accompanied by Dutch gin. The youngest and the eldest.'</p><p>'Sex wasn’t talked about in the house. The DVSV, however, provided sex education and that was where I first heard about lesbian women. It’s actually logical at a women’s society, and it was presented in a factual manner. But for me, it was an unknown phenomenon. I had quite quickly found a boyfriend who slept over. We did, however, make sure we weren’t the subject of gossip among the neighbours. Actually, boyfriends were never a problem. What’s more, they didn’t eat with us.'</p><p>'My part-time job was at the sole proprietorship Koumans. He hired me to answer the phone and have lunch with him, with a lot of French cheese and wine. I was paid monthly, four hundred guilders, I think it was. I was never in the red at the end of the month – I was simply eating a lot less. My friend from a monied family ate steak. I didn’t. I cooked for myself and Babs. We took turns cooking and ate together at the table in the kitchen.'</p><p>'Everyone could be themselves. You let each other be, there were no rules, but we did make agreements. Like tidy up after cooking. And the agreements were binding. We helped each other if we got stuck with a design. But no one said anything when I fell in love with someone else while I was still with Joop. Everyone knew, but they kept quiet, very tolerant.'</p><p>'Last week, my housemates and I and a few younger Boterbrug residents got together for a meal and a walk along the beach. On that evening, the eight of us had really open, moving talks. Here, you can talk about anything that moves you, you’re listened to here, and the way people ask questions always opens up a new topic. This openness was also present at Boterbrug reunions, especially in the speeches at the table. We feel like a family, we trust one another. You don’t need to brag. I don’t know if this continuing openness began with the first anniversary speeches Babs and I gave, it may have. In any case, when we get together now, we always have real talks with a lot of emotion. Talks about problems with your parents and about breast cancer. It’s really exceptional. Anthroposophists say that children find their parents, and maybe that’s true of our house. As if it’s always been there on some level, that you fit well together. It’s not explicit, maybe there’s a bond before you get to know each other, and then you recognise one another when you start talking. It’s recognising your housemates, not choosing them.'</p><p>'Even with the youngest housemates I immediately think “Oh, how wonderful, what fun! We know each other!” One time, at an anniversary, someone who was thirty years younger than me brought me home because I’d had too much to drink. Sweet, isn’t it? We have no pretentions, we don’t have to be beautiful or keep up a façade, we are comrades and we are kind to our neighbours. After all, they’re all sweethearts!'</p>",
+                  "format": "text/html",
+                  "language": "en",
+                  "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/c7f195ab-93ef-5bad-d356-a8a84acf4667/annotations/0/en"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": {
+        "nl": [
+          "Meisjeshuis Boterbrug 5"
+        ],
+        "en": [
+          "Boterbrug 5 Girls House"
+        ]
+      },
+      "height": 679,
+      "width": 1000,
+      "type": "Canvas",
+      "items": [
+        {
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "motivation": "painting",
+              "type": "Annotation",
+              "body": {
+                "id": "https://dlc.services/iiif-img/7/21/187c91d0-9d6d-79ab-01f5-8f2d4757e71b/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 2216,
+                "width": 3263,
+                "label": {
+                  "nl": [
+                    "-"
+                  ]
+                },
+                "service": [
+                  {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/iiif-img/7/21/187c91d0-9d6d-79ab-01f5-8f2d4757e71b",
+                    "protocol": "http://iiif.io/api/image",
+                    "width": 3263,
+                    "height": 2216,
+                    "tiles": [
+                      {
+                        "width": 256,
+                        "height": 256,
+                        "scaleFactors": [
+                          1,
+                          2,
+                          4,
+                          8,
+                          16
+                        ]
+                      }
+                    ],
+                    "sizes": [
+                      {
+                        "width": 1024,
+                        "height": 695
+                      },
+                      {
+                        "width": 400,
+                        "height": 272
+                      },
+                      {
+                        "width": 200,
+                        "height": 136
+                      },
+                      {
+                        "width": 100,
+                        "height": 68
+                      }
+                    ],
+                    "profile": [
+                      "http://iiif.io/api/image/2/level1.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "native",
+                          "color",
+                          "gray"
+                        ],
+                        "supports": [
+                          "regionByPct",
+                          "sizeByForcedWh",
+                          "sizeByWh",
+                          "sizeAboveFull",
+                          "rotationBy90s",
+                          "mirroring",
+                          "gray"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              "thumbnail": [
+                {
+                  "id": "https://dlc.services/thumbs/7/21/187c91d0-9d6d-79ab-01f5-8f2d4757e71b/full/full/0/default.jpg",
+                  "type": "Image",
+                  "service": {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/thumbs/7/21/187c91d0-9d6d-79ab-01f5-8f2d4757e71b",
+                    "protocol": "http://iiif.io/api/image",
+                    "profile": [
+                      "http://iiif.io/api/image/2/level0.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "color"
+                        ],
+                        "supports": [
+                          "sizeByWhListed"
+                        ]
+                      }
+                    ],
+                    "width": 1024,
+                    "height": 695,
+                    "sizes": [
+                      {
+                        "width": 100,
+                        "height": 68
+                      },
+                      {
+                        "width": 200,
+                        "height": 136
+                      },
+                      {
+                        "width": 400,
+                        "height": 272
+                      },
+                      {
+                        "width": 1024,
+                        "height": 695
+                      }
+                    ]
+                  }
+                }
+              ],
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/98fe5ec2-587f-74aa-2177-608e700c7e26",
+              "target": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/7f3fc73e-4abd-5cac-3817-435788b762a0#xywh=0,0,1000,679",
+              "label": {
+                "nl": [
+                  "Meisjeshuis Boterbrug 5"
+                ],
+                "en": [
+                  "Boterbrug 5 Girls House"
+                ]
+              },
+              "summary": {
+                "nl": [
+                  "Afkomstig uit de almanak van de DVSV voor het jaar 1970 (Persoonlijk archief Marjan van den Bos)"
+                ],
+                "en": [
+                  "From the 1970 DVSV Yearbook (Personal archives of Marjan van den Bos)."
+                ]
+              }
+            }
+          ],
+          "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/list/b141b9a2-86b4-4623-2ca1-2ae1ef52a895"
+        }
+      ],
+      "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/7f3fc73e-4abd-5cac-3817-435788b762a0",
+      "behavior": [
+        "w-6",
+        "h-4"
+      ]
+    },
+    {
+      "label": {
+        "nl": [
+          "Vrouwenstudies"
+        ],
+        "en": [
+          "Women’s Studies"
+        ]
+      },
+      "height": 1440,
+      "width": 2560,
+      "type": "Canvas",
+      "items": [
+        {
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "type": "Annotation",
+              "body": [
+                {
+                  "id": "https://www.youtube.com/watch?v=9fKQ1eXX-QI",
+                  "type": "Video",
+                  "service": [
+                    {
+                      "profile": "http://digirati.com/objectifier",
+                      "params": {
+                        "data": "https://www.youtube.com/embed/9fKQ1eXX-QI"
+                      }
+                    },
+                    {
+                      "id": "https://www.youtube.com/watch?v=9fKQ1eXX-QI",
+                      "profile": "https://www.youtube.com"
+                    }
+                  ]
+                }
+              ],
+              "target": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/6ac3a85d-0ee8-0c03-ca04-d62796417372#xywh=0,0,2560,1440",
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/69e1c967-a73c-8e76-9b89-fce50e2d5996",
+              "motivation": "painting",
+              "thumbnail": [
+                {
+                  "id": "https://dlc.services/thumbs/7/21/9c17b8ea-9bfb-3069-1c75-2cd0c5bf93db/full/full/0/default.jpg"
+                }
+              ],
+              "label": {
+                "nl": [
+                  "Noortje Weenink in gesprek met Anna Vos, initiatiefnemer van het vak Vrouwenstudies in 1979"
+                ],
+                "en": [
+                  "Noortje Weenink interviews Anna Vos who founded Women’s Studies in 1979"
+                ]
+              },
+              "summary": {
+                "nl": [
+                  "Geproduceerd in samenwerking met het NewMedia Centre"
+                ],
+                "en": [
+                  "Produced in collaboration with the NewMedia Centre"
+                ]
+              }
+            }
+          ],
+          "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/list/3dbc24c5-c24f-4cb1-66f3-fc3cbbde7cf6"
+        }
+      ],
+      "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/6ac3a85d-0ee8-0c03-ca04-d62796417372",
+      "behavior": [
+        "right",
+        "w-12",
+        "h-5"
+      ],
+      "summary": {
+        "nl": [
+          "Vanaf het midden van de jaren '70 stijgen zowel het aantal als het percentage eerstejaars vrouwelijke studenten gestaag. Onder invloed van de tweede feministische golf, ontstaan nieuwe initiatieven om de bestaande academische cultuur te bevragen en te veranderen. Dit vond zijn weerklank in het onderwijs.",
+          "Tijdens haar studie Bouwkunde zet Anna Vos een nieuw vak op om bestaande normen binnen het vakgebied te bevragen. Waarom worden studenten bijvoorbeeld alleen onderwezen over familiehuisvesting? In hoeverre bevestigen woningplattegronden traditionele rolverdelingen binnen het huishouden?"
+        ],
+        "en": [
+          "From the mid-seventies, both the absolute number and the relative percentage of first-year female students gradually rose. Impacted by second-wave feminism, new initiatives emerged aimed at questioning and changing the prevailing academic culture. This was echoed in education.",
+          "While studying Architecture, Anna Vos established a new discipline aimed at questioning existing norms in that field of study. For example, why were students only taught about family housing? To what extent did housing floorplans reaffirm conventional gender roles within the household?"
+        ]
+      },
+      "requiredStatement": {
+        "value": {
+          "nl": [
+            "Bekijk hier een gesprek tussen Noortje Weenink, recent afgestudeerd aan dezelfde faculteit, en Anna Vos. Samen duiken ze het archief in."
+          ],
+          "en": [
+            "Here, you can watch Noortje Weenink, a recent graduate of this faculty, interviewing Anna Vos. Together, they examine the archives."
+          ]
+        }
+      }
+    },
+    {
+      "label": {
+        "nl": [
+          "Vakomschrijving van Vrouwenstudies (1979)"
+        ],
+        "en": [
+          "Description of Womens’s Studies (1979)"
+        ]
+      },
+      "height": 1000,
+      "width": 762,
+      "type": "Canvas",
+      "items": [
+        {
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "motivation": "painting",
+              "type": "Annotation",
+              "body": {
+                "id": "https://dlc.services/iiif-img/7/21/fa878eb3-9ac0-6223-79ee-488d0ed70f72/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3490,
+                "width": 2477,
+                "label": {
+                  "nl": [
+                    "-"
+                  ]
+                },
+                "service": [
+                  {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/iiif-img/7/21/fa878eb3-9ac0-6223-79ee-488d0ed70f72",
+                    "protocol": "http://iiif.io/api/image",
+                    "width": 2477,
+                    "height": 3490,
+                    "tiles": [
+                      {
+                        "width": 256,
+                        "height": 256,
+                        "scaleFactors": [
+                          1,
+                          2,
+                          4,
+                          8,
+                          16
+                        ]
+                      }
+                    ],
+                    "sizes": [
+                      {
+                        "width": 727,
+                        "height": 1024
+                      },
+                      {
+                        "width": 284,
+                        "height": 400
+                      },
+                      {
+                        "width": 142,
+                        "height": 200
+                      },
+                      {
+                        "width": 71,
+                        "height": 100
+                      }
+                    ],
+                    "profile": [
+                      "http://iiif.io/api/image/2/level1.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "native",
+                          "color",
+                          "gray"
+                        ],
+                        "supports": [
+                          "regionByPct",
+                          "sizeByForcedWh",
+                          "sizeByWh",
+                          "sizeAboveFull",
+                          "rotationBy90s",
+                          "mirroring",
+                          "gray"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              "thumbnail": [
+                {
+                  "id": "https://dlc.services/thumbs/7/21/fa878eb3-9ac0-6223-79ee-488d0ed70f72/full/full/0/default.jpg",
+                  "type": "Image",
+                  "service": {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/thumbs/7/21/fa878eb3-9ac0-6223-79ee-488d0ed70f72",
+                    "protocol": "http://iiif.io/api/image",
+                    "profile": [
+                      "http://iiif.io/api/image/2/level0.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "color"
+                        ],
+                        "supports": [
+                          "sizeByWhListed"
+                        ]
+                      }
+                    ],
+                    "width": 727,
+                    "height": 1024,
+                    "sizes": [
+                      {
+                        "width": 71,
+                        "height": 100
+                      },
+                      {
+                        "width": 142,
+                        "height": 200
+                      },
+                      {
+                        "width": 284,
+                        "height": 400
+                      },
+                      {
+                        "width": 727,
+                        "height": 1024
+                      }
+                    ]
+                  }
+                }
+              ],
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/753a302f-6d50-d88e-9cd6-a92c33fa1cf9",
+              "target": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/554a23c9-aa7e-158e-184c-44d0cc8cb2ac#xywh=46,77,384,540",
+              "label": {
+                "nl": [
+                  "Vakomschrijving van Vrouwenstudies (1979)"
+                ],
+                "en": [
+                  "Description of Womens’s Studies (1979)"
+                ]
+              },
+              "summary": {
+                "nl": [
+                  "Archief Vrouwenstudies"
+                ],
+                "en": [
+                  "Women’s Studies Archives"
+                ]
+              }
+            },
+            {
+              "motivation": "painting",
+              "type": "Annotation",
+              "body": {
+                "id": "https://dlc.services/iiif-img/7/21/ff7a4955-4c38-93db-8878-b8c3a4bcf97d/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3495,
+                "width": 2475,
+                "label": {
+                  "nl": [
+                    "-"
+                  ]
+                },
+                "service": [
+                  {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/iiif-img/7/21/ff7a4955-4c38-93db-8878-b8c3a4bcf97d",
+                    "protocol": "http://iiif.io/api/image",
+                    "width": 2475,
+                    "height": 3495,
+                    "tiles": [
+                      {
+                        "width": 256,
+                        "height": 256,
+                        "scaleFactors": [
+                          1,
+                          2,
+                          4,
+                          8,
+                          16
+                        ]
+                      }
+                    ],
+                    "sizes": [
+                      {
+                        "width": 725,
+                        "height": 1024
+                      },
+                      {
+                        "width": 283,
+                        "height": 400
+                      },
+                      {
+                        "width": 142,
+                        "height": 200
+                      },
+                      {
+                        "width": 71,
+                        "height": 100
+                      }
+                    ],
+                    "profile": [
+                      "http://iiif.io/api/image/2/level1.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "native",
+                          "color",
+                          "gray"
+                        ],
+                        "supports": [
+                          "regionByPct",
+                          "sizeByForcedWh",
+                          "sizeByWh",
+                          "sizeAboveFull",
+                          "rotationBy90s",
+                          "mirroring",
+                          "gray"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              "thumbnail": [
+                {
+                  "id": "https://dlc.services/thumbs/7/21/ff7a4955-4c38-93db-8878-b8c3a4bcf97d/full/full/0/default.jpg",
+                  "type": "Image",
+                  "service": {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/thumbs/7/21/ff7a4955-4c38-93db-8878-b8c3a4bcf97d",
+                    "protocol": "http://iiif.io/api/image",
+                    "profile": [
+                      "http://iiif.io/api/image/2/level0.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "color"
+                        ],
+                        "supports": [
+                          "sizeByWhListed"
+                        ]
+                      }
+                    ],
+                    "width": 725,
+                    "height": 1024,
+                    "sizes": [
+                      {
+                        "width": 71,
+                        "height": 100
+                      },
+                      {
+                        "width": 142,
+                        "height": 200
+                      },
+                      {
+                        "width": 283,
+                        "height": 400
+                      },
+                      {
+                        "width": 725,
+                        "height": 1024
+                      }
+                    ]
+                  }
+                }
+              ],
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/bee8a9bd-3f4f-9800-c79f-350ef8297c92",
+              "target": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/554a23c9-aa7e-158e-184c-44d0cc8cb2ac#xywh=384,412,336,474",
+              "label": {
+                "nl": [
+                  "Vakomschrijving van Vrouwenstudies (1979)"
+                ],
+                "en": [
+                  "Description of Womens’s Studies (1979)"
+                ]
+              },
+              "summary": {
+                "nl": [
+                  "Archief Vrouwenstudies"
+                ],
+                "en": [
+                  "Women’s Studies Archives"
+                ]
+              }
+            }
+          ],
+          "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/list/6d5f6e82-db78-847c-c0ad-f44426cb9c15"
+        }
+      ],
+      "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/554a23c9-aa7e-158e-184c-44d0cc8cb2ac",
+      "behavior": [
+        "w-5",
+        "h-7"
+      ],
+      "annotations": [
+        {
+          "type": "AnnotationPage",
+          "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/554a23c9-aa7e-158e-184c-44d0cc8cb2ac/annotations",
+          "items": [
+            {
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/554a23c9-aa7e-158e-184c-44d0cc8cb2ac/annotations/113",
+              "type": "Annotation",
+              "motivation": "describing",
+              "target": {
+                "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/753a302f-6d50-d88e-9cd6-a92c33fa1cf9",
+                "type": "Annotation"
+              }
+            },
+            {
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/554a23c9-aa7e-158e-184c-44d0cc8cb2ac/annotations/114",
+              "type": "Annotation",
+              "motivation": "describing",
+              "target": {
+                "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/bee8a9bd-3f4f-9800-c79f-350ef8297c92",
+                "type": "Annotation"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": {
+        "nl": [
+          "'Je kunt zelfs hoogleraar worden'"
+        ],
+        "en": [
+          "'You can even become a professor'"
+        ]
+      },
+      "height": 2778,
+      "width": 3735,
+      "type": "Canvas",
+      "items": [
+        {
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "type": "Annotation",
+              "body": [
+                {
+                  "id": "https://www.youtube.com/watch?v=muPRP5lOWOg",
+                  "type": "Video",
+                  "service": [
+                    {
+                      "profile": "http://digirati.com/objectifier",
+                      "params": {
+                        "data": "https://www.youtube.com/embed/muPRP5lOWOg"
+                      }
+                    },
+                    {
+                      "id": "https://www.youtube.com/watch?v=muPRP5lOWOg",
+                      "profile": "https://www.youtube.com"
+                    }
+                  ]
+                }
+              ],
+              "target": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/92868b52-421e-69ab-70f5-ef5c60017ccb#xywh=0,0,3735,2778",
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/36fba69e-160b-18d1-e24e-97c2b52f2a68",
+              "motivation": "painting",
+              "thumbnail": [
+                {
+                  "id": "https://dlc.services/thumbs/7/21/c6284fdb-d7f5-0616-471e-5217f8f1033d/full/full/0/default.jpg"
+                }
+              ],
+              "summary": {
+                "nl": [
+                  "Verslag van het NOS Journaal van de meisjesinformatiedagen in 1984."
+                ],
+                "en": [
+                  "News report by the Dutch public broadcasting service NOS on the orientation days for female students in 1984. "
+                ]
+              },
+              "label": {
+                "nl": [
+                  "'Je kunt zelfs hoogleraar worden'"
+                ],
+                "en": [
+                  "'You can even become a professor'"
+                ]
+              }
+            }
+          ],
+          "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/list/6578b812-1fed-a9bc-fbad-0c351c74c921"
+        }
+      ],
+      "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/92868b52-421e-69ab-70f5-ef5c60017ccb",
+      "summary": {
+        "nl": [
+          "Verslag van het NOS Journaal van de meisjesinformatiedagen in 1984. Franziska Bollerey, in 1979 aangesteld als hoogleraar bij de Faculteit Bouwkunde, figureert in een toneelstuk getiteld 'Je kunt zelfs hoogleraar worden'. 25 jaar na Korvezee was zij de tweede vrouw met deze titel aan de TH."
+        ],
+        "en": [
+          "News report by the Dutch public broadcasting service NOS on the orientation days for female students in 1984. Franziska Bollerey, who was appointed professor at the Architecture Faculty in 1979, is featured in a play titled ‘You Can Even Become a Professor'. Twenty-five years after Korvezee, Bollerey became the second woman at the Institute of Technology to hold this title."
+        ]
+      },
+      "behavior": [
+        "bottom",
+        "w-7",
+        "h-7"
+      ]
+    },
+    {
+      "height": 1000,
+      "width": 690,
+      "type": "Canvas",
+      "items": [
+        {
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "motivation": "painting",
+              "type": "Annotation",
+              "body": {
+                "id": "https://dlc.services/iiif-img/7/23/39ba4c46-5c12-4d32-9f71-ad60a2795a0e/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3746,
+                "width": 2585,
+                "label": {
+                  "nl": [
+                    "-"
+                  ]
+                },
+                "service": [
+                  {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/iiif-img/7/23/39ba4c46-5c12-4d32-9f71-ad60a2795a0e",
+                    "protocol": "http://iiif.io/api/image",
+                    "width": 2585,
+                    "height": 3746,
+                    "tiles": [
+                      {
+                        "width": 256,
+                        "height": 256,
+                        "scaleFactors": [
+                          1,
+                          2,
+                          4,
+                          8,
+                          16
+                        ]
+                      }
+                    ],
+                    "sizes": [
+                      {
+                        "width": 707,
+                        "height": 1024
+                      },
+                      {
+                        "width": 276,
+                        "height": 400
+                      },
+                      {
+                        "width": 138,
+                        "height": 200
+                      },
+                      {
+                        "width": 69,
+                        "height": 100
+                      }
+                    ],
+                    "profile": [
+                      "http://iiif.io/api/image/2/level1.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "native",
+                          "color",
+                          "gray"
+                        ],
+                        "supports": [
+                          "regionByPct",
+                          "sizeByForcedWh",
+                          "sizeByWh",
+                          "sizeAboveFull",
+                          "rotationBy90s",
+                          "mirroring",
+                          "gray"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              "thumbnail": [
+                {
+                  "id": "https://dlc.services/thumbs/7/23/39ba4c46-5c12-4d32-9f71-ad60a2795a0e/full/full/0/default.jpg",
+                  "type": "Image",
+                  "service": {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/thumbs/7/23/39ba4c46-5c12-4d32-9f71-ad60a2795a0e",
+                    "protocol": "http://iiif.io/api/image",
+                    "profile": [
+                      "http://iiif.io/api/image/2/level0.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "color"
+                        ],
+                        "supports": [
+                          "sizeByWhListed"
+                        ]
+                      }
+                    ],
+                    "width": 707,
+                    "height": 1024,
+                    "sizes": [
+                      {
+                        "width": 69,
+                        "height": 100
+                      },
+                      {
+                        "width": 138,
+                        "height": 200
+                      },
+                      {
+                        "width": 276,
+                        "height": 400
+                      },
+                      {
+                        "width": 707,
+                        "height": 1024
+                      }
+                    ]
+                  }
+                }
+              ],
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/6ee30385-10b4-7c8d-1065-24d43e845f69",
+              "target": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/ae31c498-5cb8-247c-5cb3-d58bce409e52#xywh=0,0,690,1000",
+              "label": {
+                "nl": [
+                  "De TU Delft, een mannenwereld (1989)"
+                ],
+                "en": [
+                  "The University of Technology: A Man’s World (1989)"
+                ]
+              },
+              "summary": {
+                "nl": [
+                  "Atria, kennisinstituut voor emancipatie en vrouwengeschiedenis "
+                ],
+                "en": [
+                  "Atria, institute on gender equality and women's history"
+                ]
+              }
+            }
+          ],
+          "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/list/aade2f8c-6a49-9ea2-dd68-2f5f56d57da8"
+        }
+      ],
+      "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/ae31c498-5cb8-247c-5cb3-d58bce409e52",
+      "behavior": [
+        "left",
+        "w-12",
+        "h-6"
+      ],
+      "requiredStatement": {
+        "value": {
+          "nl": [
+            "Bekijk het volledige boek door te klikken op het beeld en vervolgens op 'Bekijk object'."
+          ],
+          "en": [
+            "View the complete book by clicking the image and then 'View object'."
+          ]
+        }
+      },
+      "label": {
+        "en": [
+          "Cracks in the bulwarks?"
+        ],
+        "nl": [
+          "Barsten in het bolwerk?"
+        ]
+      },
+      "summary": {
+        "nl": [
+          "Ondanks het groeide aandeel vrouwen en de invloed van de tweede feministische golf, blijft de TH, sinds 1986 TU Delft genaamd, een mannenbolwerk. In het project 'De technische universiteit, een mannenwereld' uit 1989 benadert Studium Generale het probleem vanaf de andere kant: de mannen. \"...als er geen barsten in dit bolwerk ontstaan en de mannen niet óók een verandering willen, zal deze er ook niet komen,\" aldus het voorwoord.",
+          "Maar wat is een mannengemeenschap? Wat zijn de stereotype rollenpatronen die doorbroken moeten worden? En welke blokkades werpen deze op voor het gelijkwaardig functioneren van vrouwen? In een publicatie wordt gezocht naar antwoorden op deze vragen, die tegenwoordig nog steeds relevant zijn.",
+          ""
+        ],
+        "en": [
+          "Despite the rising percentage of female students and the impact of second-wave feminism, the Institute of Technology (renamed TU Delft in 1986) remains a men’s stronghold. In the 1989 project ‘De technische universiteit, een mannenwereld' (The University of Technology: A Man’s World) Studium Generale approaches the problem from the other side: the men’s side. ‘(...) if no cracks appear in the bulwarks and the men also remain resistant to change, there will be no change’ the foreword reads.",
+          "But what is a community of men? What are the gender role stereotypes that must be broken? And what obstacles do they present to women’s equality in the workplace and beyond? In the publication, answers are sought to these questions – questions that remain relevant today."
+        ]
+      }
+    },
+    {
+      "label": {
+        "nl": [
+          "Verder lezen?"
+        ],
+        "en": [
+          "Like to read more?"
+        ]
+      },
+      "height": 679,
+      "width": 1000,
+      "type": "Canvas",
+      "items": [
+        {
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "motivation": "painting",
+              "type": "Annotation",
+              "body": {
+                "id": "https://dlc.services/iiif-img/7/6/1641f326-5ebb-4b55-839d-b6e7dd748683/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 4672,
+                "width": 3328,
+                "label": {
+                  "nl": [
+                    "-"
+                  ]
+                },
+                "service": [
+                  {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/iiif-img/7/6/1641f326-5ebb-4b55-839d-b6e7dd748683",
+                    "protocol": "http://iiif.io/api/image",
+                    "width": 3328,
+                    "height": 4672,
+                    "tiles": [
+                      {
+                        "width": 256,
+                        "height": 256,
+                        "scaleFactors": [
+                          1,
+                          2,
+                          4,
+                          8,
+                          16,
+                          32
+                        ]
+                      }
+                    ],
+                    "sizes": [
+                      {
+                        "width": 729,
+                        "height": 1024
+                      },
+                      {
+                        "width": 285,
+                        "height": 400
+                      },
+                      {
+                        "width": 142,
+                        "height": 200
+                      },
+                      {
+                        "width": 71,
+                        "height": 100
+                      }
+                    ],
+                    "profile": [
+                      "http://iiif.io/api/image/2/level1.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "native",
+                          "color",
+                          "gray"
+                        ],
+                        "supports": [
+                          "regionByPct",
+                          "sizeByForcedWh",
+                          "sizeByWh",
+                          "sizeAboveFull",
+                          "rotationBy90s",
+                          "mirroring",
+                          "gray"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              "thumbnail": [
+                {
+                  "id": "https://dlc.services/thumbs/7/6/1641f326-5ebb-4b55-839d-b6e7dd748683/full/full/0/default.jpg",
+                  "type": "Image",
+                  "service": {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/thumbs/7/6/1641f326-5ebb-4b55-839d-b6e7dd748683",
+                    "protocol": "http://iiif.io/api/image",
+                    "profile": [
+                      "http://iiif.io/api/image/2/level0.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "color"
+                        ],
+                        "supports": [
+                          "sizeByWhListed"
+                        ]
+                      }
+                    ],
+                    "width": 729,
+                    "height": 1024,
+                    "sizes": [
+                      {
+                        "width": 71,
+                        "height": 100
+                      },
+                      {
+                        "width": 142,
+                        "height": 200
+                      },
+                      {
+                        "width": 285,
+                        "height": 400
+                      },
+                      {
+                        "width": 729,
+                        "height": 1024
+                      }
+                    ]
+                  }
+                }
+              ],
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/8523fe29-cb1a-7a51-be0b-22415ba86745",
+              "target": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/f4519824-8482-4d56-18cb-03ff6aad2736#xywh=21,21,338,473",
+              "label": {
+                "nl": [
+                  "Almanak van de Delftsche Vrouwelijke Studenten Vereeniging (1994)"
+                ],
+                "en": [
+                  "Almanak van de Delftsche Vrouwelijke Studenten Vereeniging (1994)"
+                ]
+              },
+              "summary": {
+                "nl": [
+                  "TU Delft Library"
+                ],
+                "en": [
+                  "TU Delft Library"
+                ]
+              }
+            },
+            {
+              "motivation": "painting",
+              "type": "Annotation",
+              "body": {
+                "id": "https://dlc.services/iiif-img/7/6/69f7f9b7-03fe-4b30-8038-7a63c8cbfa23/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3808,
+                "width": 3200,
+                "label": {
+                  "nl": [
+                    "-"
+                  ]
+                },
+                "service": [
+                  {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/iiif-img/7/6/69f7f9b7-03fe-4b30-8038-7a63c8cbfa23",
+                    "protocol": "http://iiif.io/api/image",
+                    "width": 3200,
+                    "height": 3808,
+                    "tiles": [
+                      {
+                        "width": 256,
+                        "height": 256,
+                        "scaleFactors": [
+                          1,
+                          2,
+                          4,
+                          8,
+                          16
+                        ]
+                      }
+                    ],
+                    "sizes": [
+                      {
+                        "width": 861,
+                        "height": 1024
+                      },
+                      {
+                        "width": 336,
+                        "height": 400
+                      },
+                      {
+                        "width": 168,
+                        "height": 200
+                      },
+                      {
+                        "width": 84,
+                        "height": 100
+                      }
+                    ],
+                    "profile": [
+                      "http://iiif.io/api/image/2/level1.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "native",
+                          "color",
+                          "gray"
+                        ],
+                        "supports": [
+                          "regionByPct",
+                          "sizeByForcedWh",
+                          "sizeByWh",
+                          "sizeAboveFull",
+                          "rotationBy90s",
+                          "mirroring",
+                          "gray"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              "thumbnail": [
+                {
+                  "id": "https://dlc.services/thumbs/7/6/69f7f9b7-03fe-4b30-8038-7a63c8cbfa23/full/full/0/default.jpg",
+                  "type": "Image",
+                  "service": {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/thumbs/7/6/69f7f9b7-03fe-4b30-8038-7a63c8cbfa23",
+                    "protocol": "http://iiif.io/api/image",
+                    "profile": [
+                      "http://iiif.io/api/image/2/level0.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "color"
+                        ],
+                        "supports": [
+                          "sizeByWhListed"
+                        ]
+                      }
+                    ],
+                    "width": 861,
+                    "height": 1024,
+                    "sizes": [
+                      {
+                        "width": 84,
+                        "height": 100
+                      },
+                      {
+                        "width": 168,
+                        "height": 200
+                      },
+                      {
+                        "width": 336,
+                        "height": 400
+                      },
+                      {
+                        "width": 861,
+                        "height": 1024
+                      }
+                    ]
+                  }
+                }
+              ],
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/06031e13-e770-9dc7-7649-40f3c7b2ad7e",
+              "target": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/f4519824-8482-4d56-18cb-03ff6aad2736#xywh=266,238,348,413",
+              "label": {
+                "nl": [
+                  "Vrouwen in techniek: 90 jaar Delftse vrouwelijke ingenieurs (1995)"
+                ],
+                "en": [
+                  "Vrouwen in techniek: 90 jaar Delftse vrouwelijke ingenieurs (1995)"
+                ]
+              },
+              "summary": {
+                "nl": [
+                  "TU Delft Library"
+                ],
+                "en": [
+                  "TU Delft Library"
+                ]
+              }
+            },
+            {
+              "motivation": "painting",
+              "type": "Annotation",
+              "body": {
+                "id": "https://dlc.services/iiif-img/7/23/d232fb19-02b2-46c0-a6ec-91b502bd667c/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 4646,
+                "width": 3184,
+                "label": {
+                  "nl": [
+                    "-"
+                  ]
+                },
+                "service": [
+                  {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/iiif-img/7/23/d232fb19-02b2-46c0-a6ec-91b502bd667c",
+                    "protocol": "http://iiif.io/api/image",
+                    "width": 3184,
+                    "height": 4646,
+                    "tiles": [
+                      {
+                        "width": 256,
+                        "height": 256,
+                        "scaleFactors": [
+                          1,
+                          2,
+                          4,
+                          8,
+                          16,
+                          32
+                        ]
+                      }
+                    ],
+                    "sizes": [
+                      {
+                        "width": 702,
+                        "height": 1024
+                      },
+                      {
+                        "width": 274,
+                        "height": 400
+                      },
+                      {
+                        "width": 137,
+                        "height": 200
+                      },
+                      {
+                        "width": 69,
+                        "height": 100
+                      }
+                    ],
+                    "profile": [
+                      "http://iiif.io/api/image/2/level1.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "native",
+                          "color",
+                          "gray"
+                        ],
+                        "supports": [
+                          "regionByPct",
+                          "sizeByForcedWh",
+                          "sizeByWh",
+                          "sizeAboveFull",
+                          "rotationBy90s",
+                          "mirroring",
+                          "gray"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              "thumbnail": [
+                {
+                  "id": "https://dlc.services/thumbs/7/23/d232fb19-02b2-46c0-a6ec-91b502bd667c/full/full/0/default.jpg",
+                  "type": "Image",
+                  "service": {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/thumbs/7/23/d232fb19-02b2-46c0-a6ec-91b502bd667c",
+                    "protocol": "http://iiif.io/api/image",
+                    "profile": [
+                      "http://iiif.io/api/image/2/level0.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "color"
+                        ],
+                        "supports": [
+                          "sizeByWhListed"
+                        ]
+                      }
+                    ],
+                    "width": 702,
+                    "height": 1024,
+                    "sizes": [
+                      {
+                        "width": 69,
+                        "height": 100
+                      },
+                      {
+                        "width": 137,
+                        "height": 200
+                      },
+                      {
+                        "width": 274,
+                        "height": 400
+                      },
+                      {
+                        "width": 702,
+                        "height": 1024
+                      }
+                    ]
+                  }
+                }
+              ],
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/306ca6cd-a840-a917-3bbd-29232ed0e5e6",
+              "target": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/f4519824-8482-4d56-18cb-03ff6aad2736#xywh=504,21,284,413",
+              "label": {
+                "nl": [
+                  "Vrouwen die techniek studeren... hoe apart (1984)"
+                ],
+                "en": [
+                  "Vrouwen die techniek studeren... hoe apart (1984)"
+                ]
+              },
+              "summary": {
+                "nl": [
+                  "Atria, kennisinstituut voor emancipatie en vrouwengeschiedenis"
+                ],
+                "en": [
+                  "Atria, institute on gender equality and women's history"
+                ]
+              }
+            },
+            {
+              "motivation": "painting",
+              "type": "Annotation",
+              "body": {
+                "id": "https://dlc.services/iiif-img/7/23/c7f16b95-d4dd-4596-875b-12a2652d7670/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 3270,
+                "width": 2334,
+                "label": {
+                  "nl": [
+                    "-"
+                  ]
+                },
+                "service": [
+                  {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/iiif-img/7/23/c7f16b95-d4dd-4596-875b-12a2652d7670",
+                    "protocol": "http://iiif.io/api/image",
+                    "width": 2334,
+                    "height": 3270,
+                    "tiles": [
+                      {
+                        "width": 256,
+                        "height": 256,
+                        "scaleFactors": [
+                          1,
+                          2,
+                          4,
+                          8,
+                          16
+                        ]
+                      }
+                    ],
+                    "sizes": [
+                      {
+                        "width": 731,
+                        "height": 1024
+                      },
+                      {
+                        "width": 286,
+                        "height": 400
+                      },
+                      {
+                        "width": 143,
+                        "height": 200
+                      },
+                      {
+                        "width": 71,
+                        "height": 100
+                      }
+                    ],
+                    "profile": [
+                      "http://iiif.io/api/image/2/level1.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "native",
+                          "color",
+                          "gray"
+                        ],
+                        "supports": [
+                          "regionByPct",
+                          "sizeByForcedWh",
+                          "sizeByWh",
+                          "sizeAboveFull",
+                          "rotationBy90s",
+                          "mirroring",
+                          "gray"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              "thumbnail": [
+                {
+                  "id": "https://dlc.services/thumbs/7/23/c7f16b95-d4dd-4596-875b-12a2652d7670/full/full/0/default.jpg",
+                  "type": "Image",
+                  "service": {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/thumbs/7/23/c7f16b95-d4dd-4596-875b-12a2652d7670",
+                    "protocol": "http://iiif.io/api/image",
+                    "profile": [
+                      "http://iiif.io/api/image/2/level0.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "color"
+                        ],
+                        "supports": [
+                          "sizeByWhListed"
+                        ]
+                      }
+                    ],
+                    "width": 731,
+                    "height": 1024,
+                    "sizes": [
+                      {
+                        "width": 71,
+                        "height": 100
+                      },
+                      {
+                        "width": 143,
+                        "height": 200
+                      },
+                      {
+                        "width": 286,
+                        "height": 400
+                      },
+                      {
+                        "width": 731,
+                        "height": 1024
+                      }
+                    ]
+                  }
+                }
+              ],
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/7a84546b-2cf9-6293-9fc4-e50220bf0101",
+              "target": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/f4519824-8482-4d56-18cb-03ff6aad2736#xywh=696,250,277,387",
+              "label": {
+                "nl": [
+                  "THD-vrouwendag 1985 : lezingen - vraagstelling - forum"
+                ],
+                "en": [
+                  "THD-vrouwendag 1985 : lezingen - vraagstelling - forum"
+                ]
+              },
+              "summary": {
+                "nl": [
+                  "Atria, kennisinstituut voor emancipatie en vrouwengeschiedenis"
+                ],
+                "en": [
+                  "Atria, institute on gender equality and women's history"
+                ]
+              }
+            }
+          ],
+          "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/list/116f4b96-eb56-8d81-81dc-3441c7b9db99"
+        }
+      ],
+      "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/f4519824-8482-4d56-18cb-03ff6aad2736",
+      "behavior": [
+        "w-8",
+        "h-6"
+      ],
+      "annotations": [
+        {
+          "type": "AnnotationPage",
+          "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/f4519824-8482-4d56-18cb-03ff6aad2736/annotations",
+          "items": [
+            {
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/f4519824-8482-4d56-18cb-03ff6aad2736/annotations/117",
+              "type": "Annotation",
+              "motivation": "describing",
+              "target": {
+                "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/8523fe29-cb1a-7a51-be0b-22415ba86745",
+                "type": "Annotation"
+              }
+            },
+            {
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/f4519824-8482-4d56-18cb-03ff6aad2736/annotations/118",
+              "type": "Annotation",
+              "motivation": "describing",
+              "target": {
+                "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/06031e13-e770-9dc7-7649-40f3c7b2ad7e",
+                "type": "Annotation"
+              }
+            },
+            {
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/f4519824-8482-4d56-18cb-03ff6aad2736/annotations/119",
+              "type": "Annotation",
+              "motivation": "describing",
+              "target": {
+                "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/306ca6cd-a840-a917-3bbd-29232ed0e5e6",
+                "type": "Annotation"
+              }
+            },
+            {
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/f4519824-8482-4d56-18cb-03ff6aad2736/annotations/120",
+              "type": "Annotation",
+              "motivation": "describing",
+              "target": {
+                "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/7a84546b-2cf9-6293-9fc4-e50220bf0101",
+                "type": "Annotation"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "height": 1000,
+      "width": 1000,
+      "type": "Canvas",
+      "items": [
+        {
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "type": "Annotation",
+              "body": [
+                {
+                  "type": "TextualBody",
+                  "value": "<h1>Bibliografie</h1>\n\n<p>Verschillende bronnen zijn gedigitaliseerd in het kader van deze tentoonstelling. Klik hieronder op 'Verder lezen' voor een uitgebreidere bibliografie.</p>",
+                  "format": "text/html",
+                  "language": "nl",
+                  "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/textualbody/ab68dad5-fe33-1835-dd6c-5cf0adcffef1/nl"
+                },
+                {
+                  "type": "TextualBody",
+                  "value": "<h1>Bibliography</h1>\n\n<p>Several source texts have been digitised for this exhibition. Click  'Read More' for a more extensive bibliography.</p>",
+                  "format": "text/html",
+                  "language": "en",
+                  "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/textualbody/ab68dad5-fe33-1835-dd6c-5cf0adcffef1/en"
+                }
+              ],
+              "target": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/46ce51f6-f3be-7ac8-6e54-48d3b5dffc4e",
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/annotation/9b64ade1-3240-2a6c-c8fb-7aec6cd30b1a",
+              "motivation": "painting"
+            }
+          ],
+          "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/list/9a9737d8-2e14-c013-b115-384f35b50665"
+        }
+      ],
+      "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/46ce51f6-f3be-7ac8-6e54-48d3b5dffc4e",
+      "behavior": [
+        "info",
+        "w-4",
+        "h-6"
+      ],
+      "annotations": [
+        {
+          "type": "AnnotationPage",
+          "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/46ce51f6-f3be-7ac8-6e54-48d3b5dffc4e/annotations",
+          "items": [
+            {
+              "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/46ce51f6-f3be-7ac8-6e54-48d3b5dffc4e/annotations/0",
+              "type": "Annotation",
+              "motivation": "describing",
+              "target": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/46ce51f6-f3be-7ac8-6e54-48d3b5dffc4e",
+              "body": [
+                {
+                  "type": "TextualBody",
+                  "value": "<h1>Bibliografie</h1>\n\n<h2>Algemeen</h2><ul><li>Damme-van Weele, Marina van; Jacobien Ressing-Wolfert (1995) <em>Vrouwen in techniek: 90 jaar Delftse vrouwelijke ingenieurs</em>, Delft: Deltech uitgevers. <a href=\"https://erfgoed.tudelft.nl/nl/objects/txf-vrouwen-in-techniek\" rel=\"noopener noreferrer\" target=\"_blank\">Digitaal</a>. Bij het <a href=\"https://hdl.handle.net/21.12115/NL-DtAD6154772\" rel=\"noopener noreferrer\" target=\"_blank\">Stadsarchief Delft</a> is een archief beschikbaar van het werkmateriaal voor deze uitgave.</li><li>Giezen , R. (1985) <em>THD-vrouwendag 1985 : lezingen - vraagstelling - forum</em>, Delft: Technische Hogeschool Delft. <a href=\"https://erfgoed.tudelft.nl/nl/objects/060b8bee-939c-480e-abdf-70beb96f86ce/?id=0\" rel=\"noopener noreferrer\" target=\"_blank\">Digitaal</a></li><li>Gillissen, Nannie; Anneke Lissenberg (1984) <em>Vrouwen in een mannenbolwerk: een vergelijkend onderzoek naar de ervaringen van vrouwelijke studenten in de jaren vijftig en zeventig aan de Technische Hogeschool Delft</em>, Amsterdam: Sociologisch Instituut (doctoraalscriptie sociologie), Universiteit van Amsterdam. <a href=\"https://scripties.uba.uva.nl/scriptie/572806\" rel=\"noopener noreferrer\" target=\"_blank\">Digitaal</a></li><li>Haas, W. de (1963) “Onze eerste vrouwelijke studenten” in <em>T.H. Mededelingen</em>, jaargang 10, nummer 9, mei 1963.</li><li>Jong, Frida de (1984) <em>Vrouwen die techniek studeren... hoe apart</em>, Delft: Technische Hogeschool Delft. <a href=\"https://erfgoed.tudelft.nl/nl/objects/95e034c9-58fb-4430-85dd-9d1e69f55c31/?id=0\" rel=\"noopener noreferrer\" target=\"_blank\">Digitaal</a></li><li>Jong, Frida de (1997), “Standhouden in Delft” in <em>Gewina</em>, 20, 227-242. <a href=\"http://resources.huygens.knaw.nl/retroboeken/gewina/?page=223&amp;source=source_volume_20\" rel=\"noopener noreferrer\" target=\"_blank\">Digitaal</a>, zie ook de <a href=\"http://resources.huygens.knaw.nl/retroboeken/gewina/?page=169&amp;source=source_volume_20\" rel=\"noopener noreferrer\" target=\"_blank\">introductie</a> van dit nummer (\"Zy is toch wel zeer begaafd’. Historische bijdragen over vrouwen in de bètawetenschappen\").</li><li>Knippenberg, W.J.M. (1994) <em>Vrouwen in de Techniek, opening academisch jaar 1994</em>, Delft: TH Delft, september 1994. <a href=\"http://resolver.tudelft.nl/uuid:9c8a79dc-bd75-4a4b-9dca-4ad09156a919\" rel=\"noopener noreferrer\" target=\"_blank\">Digitaal</a></li><li>Lieshout, René van; Lex Veldhoen; Johan den Hartog (1989) <em>De Technische Universiteit, een mannenwereld</em>, Delft: Studium Generale TU Delft. <a href=\"https://erfgoed.tudelft.nl/nl/objects/901aa23e-a3f2-448a-a82f-885ba412761a\" rel=\"noopener noreferrer\" target=\"_blank\">Digitaal</a></li><li>Wijk, Charlotte van (2018) “Women’s Studies at the Architecture Department” in <em>MoMoWo, Women’s Creativity since the Modern Movement: Toward a New Perception and Reception</em>. <a href=\"https://uifs.zrc-sazu.si/sites/default/files/momowo_torin_2018_final.pdf\" rel=\"noopener noreferrer\" target=\"_blank\">Digitaal</a></li></ul><h2>Statistieken</h2><p>Statistieken over de periode 2002-2018 zijn beschikbaar op de <a href=\"https://www.tudelft.nl/over-tu-delft/feiten-en-cijfers/onderwijs/\" rel=\"noopener noreferrer\" target=\"_blank\">website</a> van de TU Delft.</p><p>De <a href=\"https://tudelft.on.worldcat.org/oclc/72790063\" rel=\"noopener noreferrer\" target=\"_blank\">jaarboeken</a> van de Technische Hoogeschool Delft (1917-1969) bevatten statistieken over de eerst ingeschreven studenten, het totale aantal studenten en het aantal geslaagde studenten. De jaarboeken van de periode 1916-1951 zijn <a href=\"https://tresor.tudelft.nl/tijdschrift/jaarboeken/\" rel=\"noopener noreferrer\" target=\"_blank\">gedigitaliseerd</a>. Het eerste jaarboek uit 1916 bevat gegevens over de periode 1905-1915. De jaarboeken gaan over in het <a href=\"https://tudelft.on.worldcat.org/oclc/911004546\" rel=\"noopener noreferrer\" target=\"_blank\">Verslag over de Technische Hogeschool te Delft</a>. Vanaf de jaren tachtig is het uitgebreidere Statistisch jaarboek beschikbaar (<a href=\"https://tudelft.on.worldcat.org/oclc/72761474\" rel=\"noopener noreferrer\" target=\"_blank\">periode 1982-1986</a>, <a href=\"https://tudelft.on.worldcat.org/oclc/72961283\" rel=\"noopener noreferrer\" target=\"_blank\">periode 1987-2002</a>).</p><p>Voor deze tentoonstelling zijn geen statistieken geraadpleegd voor de periode van de Koninklijke Academie (1842-1864) of Polytechnische school (1864-1905) omdat vrouwelijke studenten toen niet de mogelijkheid hadden om voltijds te studeren.</p><h2>Delftsche Vrouwelijke Studentenvereniging</h2><p>De almanakken van de DVSV van de periode 1914-49 zijn gedigitaliseerd en te raadplegen op <a href=\"https://www.delpher.nl/nl/tijdschriften/results?facets%5BalternativeFacet%5D%5B%5D=Almanak+van+de+Delftsche+Vrouwelijke+Studenten+Vereeniging+voor+...&amp;facets%5BalternativeFacet%5D%5B%5D=Almanak+der+Delftsche+Vrouwelijke+Studenten+Vereeniging&amp;page=1&amp;sortfield=date&amp;cql%5B%5D=(source+exact+%22TU+Delft+Library%22)&amp;coll=dts\" rel=\"noopener noreferrer\" target=\"_blank\">Delpher</a>. De almanakken uit <a href=\"https://erfgoed.tudelft.nl/nl/objects/tr-almanak-dvsv-1930\" rel=\"noopener noreferrer\" target=\"_blank\">1930</a> en <a href=\"https://erfgoed.tudelft.nl/nl/objects/tr-almanak-dvsv-1931\" rel=\"noopener noreferrer\" target=\"_blank\">1931</a> zijn ook te vinden op deze website samen met een <a href=\"https://erfgoed.tudelft.nl/nl/objects/tr-almanak-dvsv-1994\" rel=\"noopener noreferrer\" target=\"_blank\">jubileumuitgave</a> uit 1994, 100 jaar na de oprichting van de vereniging. Het archief van de DVSV bevindt zich in het <a href=\"https://hdl.handle.net/21.12115/NL-DtAD5810053\" rel=\"noopener noreferrer\" target=\"_blank\">Stadsarchief Delft</a>.</p><h2>Archief Vrouwenstudies</h2><p>Het archief van Vrouwenstudies is door Anna Vos geschonken aan de Faculteit Bouwkunde. Momenteel wordt er gezocht naar een permanente bewaarplek. Contactpersonen voor inzage in het archief zijn <a href=\"https://www.tudelft.nl/staff/c.a.vanwijk/\" rel=\"noopener noreferrer\" target=\"_blank\">Charlotte van Wijk</a> (Faculteit Bouwkunde) en <a href=\"https://www.tudelft.nl/library/over-the-library/contact-en-bereikbaarheid/\" rel=\"noopener noreferrer\" target=\"_blank\">Jules Schoonman</a> (TU Delft Library).</p>",
+                  "format": "text/html",
+                  "language": "nl",
+                  "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/46ce51f6-f3be-7ac8-6e54-48d3b5dffc4e/annotations/0/nl"
+                },
+                {
+                  "type": "TextualBody",
+                  "value": "<h1>Bibliography</h1>\n\n<p><em>Only available in Dutch</em></p><h2>Algemeen</h2><ul><li>Damme-van Weele, Marina van; Jacobien Ressing-Wolfert (1995) <em>Vrouwen in techniek: 90 jaar Delftse vrouwelijke ingenieurs</em>, Delft: Deltech uitgevers. <a href=\"https://erfgoed.tudelft.nl/nl/objects/txf-vrouwen-in-techniek\" rel=\"noopener noreferrer\" target=\"_blank\">Digitaal</a>. Bij het <a href=\"https://hdl.handle.net/21.12115/NL-DtAD6154772\" rel=\"noopener noreferrer\" target=\"_blank\">Stadsarchief Delft</a> is een archief beschikbaar van het werkmateriaal voor deze uitgave.</li><li>Giezen , R. (1985) <em>THD-vrouwendag 1985 : lezingen - vraagstelling - forum</em>, Delft: Technische Hogeschool Delft. <a href=\"https://erfgoed.tudelft.nl/nl/objects/060b8bee-939c-480e-abdf-70beb96f86ce/?id=0\" rel=\"noopener noreferrer\" target=\"_blank\">Digitaal</a></li><li>Gillissen, Nannie; Anneke Lissenberg (1984) <em>Vrouwen in een mannenbolwerk: een vergelijkend onderzoek naar de ervaringen van vrouwelijke studenten in de jaren vijftig en zeventig aan de Technische Hogeschool Delft</em>, Amsterdam: Sociologisch Instituut (doctoraalscriptie sociologie), Universiteit van Amsterdam. <a href=\"https://scripties.uba.uva.nl/scriptie/572806\" rel=\"noopener noreferrer\" target=\"_blank\">Digitaal</a></li><li>Haas, W. de (1963) “Onze eerste vrouwelijke studenten” in <em>T.H. Mededelingen</em>, jaargang 10, nummer 9, mei 1963.</li><li>Jong, Frida de (1984) <em>Vrouwen die techniek studeren... hoe apart</em>, Delft: Technische Hogeschool Delft. <a href=\"https://erfgoed.tudelft.nl/nl/objects/95e034c9-58fb-4430-85dd-9d1e69f55c31/?id=0\" rel=\"noopener noreferrer\" target=\"_blank\">Digitaal</a></li><li>Jong, Frida de (1997), “Standhouden in Delft” in <em>Gewina</em>, 20, 227-242. <a href=\"http://resources.huygens.knaw.nl/retroboeken/gewina/?page=223&amp;source=source_volume_20\" rel=\"noopener noreferrer\" target=\"_blank\">Digitaal</a>, zie ook de <a href=\"http://resources.huygens.knaw.nl/retroboeken/gewina/?page=169&amp;source=source_volume_20\" rel=\"noopener noreferrer\" target=\"_blank\">introductie</a> van dit nummer (\"Zy is toch wel zeer begaafd’. Historische bijdragen over vrouwen in de bètawetenschappen\").</li><li>Knippenberg, W.J.M. (1994) <em>Vrouwen in de Techniek, opening academisch jaar 1994</em>, Delft: TH Delft, september 1994. <a href=\"http://resolver.tudelft.nl/uuid:9c8a79dc-bd75-4a4b-9dca-4ad09156a919\" rel=\"noopener noreferrer\" target=\"_blank\">Digitaal</a></li><li>Lieshout, René van; Lex Veldhoen; Johan den Hartog (1989) <em>De Technische Universiteit, een mannenwereld</em>, Delft: Studium Generale TU Delft. <a href=\"https://erfgoed.tudelft.nl/nl/objects/901aa23e-a3f2-448a-a82f-885ba412761a\" rel=\"noopener noreferrer\" target=\"_blank\">Digitaal</a></li><li>Wijk, Charlotte van (2018) “Women’s Studies at the Architecture Department” in <em>MoMoWo, Women’s Creativity since the Modern Movement: Toward a New Perception and Reception</em>. <a href=\"https://uifs.zrc-sazu.si/sites/default/files/momowo_torin_2018_final.pdf\" rel=\"noopener noreferrer\" target=\"_blank\">Digitaal</a></li></ul><h2>Statistieken</h2><p>Statistieken over de periode 2002-2018 zijn beschikbaar op de <a href=\"https://www.tudelft.nl/over-tu-delft/feiten-en-cijfers/onderwijs/\" rel=\"noopener noreferrer\" target=\"_blank\">website</a> van de TU Delft.</p><p>De <a href=\"https://tudelft.on.worldcat.org/oclc/72790063\" rel=\"noopener noreferrer\" target=\"_blank\">jaarboeken</a> van de Technische Hoogeschool Delft (1917-1969) bevatten statistieken over de eerst ingeschreven studenten, het totale aantal studenten en het aantal geslaagde studenten. De jaarboeken van de periode 1916-1951 zijn <a href=\"https://tresor.tudelft.nl/tijdschrift/jaarboeken/\" rel=\"noopener noreferrer\" target=\"_blank\">gedigitaliseerd</a>. Het eerste jaarboek uit 1916 bevat gegevens over de periode 1905-1915. De jaarboeken gaan over in het <a href=\"https://tudelft.on.worldcat.org/oclc/911004546\" rel=\"noopener noreferrer\" target=\"_blank\">Verslag over de Technische Hogeschool te Delft</a>. Vanaf de jaren tachtig is het uitgebreidere Statistisch jaarboek beschikbaar (<a href=\"https://tudelft.on.worldcat.org/oclc/72761474\" rel=\"noopener noreferrer\" target=\"_blank\">periode 1982-1986</a>, <a href=\"https://tudelft.on.worldcat.org/oclc/72961283\" rel=\"noopener noreferrer\" target=\"_blank\">periode 1987-2002</a>).</p><p>Voor deze tentoonstelling zijn geen statistieken geraadpleegd voor de periode van de Koninklijke Academie (1842-1864) of Polytechnische school (1864-1905) omdat vrouwelijke studenten toen niet de mogelijkheid hadden om voltijds te studeren.</p><h2>Delftsche Vrouwelijke Studentenvereniging</h2><p>De almanakken van de DVSV van de periode 1914-49 zijn gedigitaliseerd en te raadplegen op <a href=\"https://www.delpher.nl/nl/tijdschriften/results?facets%5BalternativeFacet%5D%5B%5D=Almanak+van+de+Delftsche+Vrouwelijke+Studenten+Vereeniging+voor+...&amp;facets%5BalternativeFacet%5D%5B%5D=Almanak+der+Delftsche+Vrouwelijke+Studenten+Vereeniging&amp;page=1&amp;sortfield=date&amp;cql%5B%5D=(source+exact+%22TU+Delft+Library%22)&amp;coll=dts\" rel=\"noopener noreferrer\" target=\"_blank\">Delpher</a>. De almanakken uit <a href=\"https://erfgoed.tudelft.nl/nl/objects/tr-almanak-dvsv-1930\" rel=\"noopener noreferrer\" target=\"_blank\">1930</a> en <a href=\"https://erfgoed.tudelft.nl/nl/objects/tr-almanak-dvsv-1931\" rel=\"noopener noreferrer\" target=\"_blank\">1931</a> zijn ook te vinden op deze website samen met een <a href=\"https://erfgoed.tudelft.nl/nl/objects/tr-almanak-dvsv-1994\" rel=\"noopener noreferrer\" target=\"_blank\">jubileumuitgave</a> uit 1994, 100 jaar na de oprichting van de vereniging. Het archief van de DVSV bevindt zich in het <a href=\"https://hdl.handle.net/21.12115/NL-DtAD5810053\" rel=\"noopener noreferrer\" target=\"_blank\">Stadsarchief Delft</a>.</p><h2>Archief Vrouwenstudies</h2><p>Het archief van Vrouwenstudies is door Anna Vos geschonken aan de Faculteit Bouwkunde. Momenteel wordt er gezocht naar een permanente bewaarplek. Contactpersonen voor inzage in het archief zijn <a href=\"https://www.tudelft.nl/staff/c.a.vanwijk/\" rel=\"noopener noreferrer\" target=\"_blank\">Charlotte van Wijk</a> (Faculteit Bouwkunde) en <a href=\"https://www.tudelft.nl/library/over-the-library/contact-en-bereikbaarheid/\" rel=\"noopener noreferrer\" target=\"_blank\">Jules Schoonman</a> (TU Delft Library).</p>",
+                  "format": "text/html",
+                  "language": "en",
+                  "id": "https://heritage.tudelft.nl/iiif/62d39710-83ec-5064-a890-2bb3845cb67d/canvas/46ce51f6-f3be-7ac8-6e54-48d3b5dffc4e/annotations/0/en"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "id": "https://heritage.tudelft.nl/iiif/novieten/manifest",
+  "homepage": [
+    {
+      "id": "https://heritage.tudelft.nl/nl/exhibitions/novieten",
+      "type": "Text",
+      "format": "text/html",
+      "language": [
+        "nl"
+      ]
+    },
+    {
+      "id": "https://heritage.tudelft.nl/en/exhibitions/novieten",
+      "type": "Text",
+      "format": "text/html",
+      "language": [
+        "en"
+      ]
+    }
+  ]
+}

--- a/src/annotation-targets/expand-target.ts
+++ b/src/annotation-targets/expand-target.ts
@@ -1,4 +1,4 @@
-import { ExternalWebResource, W3CAnnotationTarget } from '@iiif/presentation-3';
+import { ExternalWebResource, W3CAnnotationTarget, AnnotationTarget, ImageApiSelector } from '@iiif/presentation-3';
 import { SupportedTarget } from './target-types';
 import { parseSelector } from './parse-selector';
 

--- a/src/annotation-targets/selector-types.ts
+++ b/src/annotation-targets/selector-types.ts
@@ -1,3 +1,5 @@
+import { ImageApiSelector } from '@iiif/presentation-3';
+
 export type SvgShapeType = 'rect' | 'circle' | 'ellipse' | 'line' | 'polyline' | 'polygon' | 'path';
 export interface SupportedSelector {
   type: string;
@@ -12,6 +14,7 @@ export interface SupportedSelector {
     width?: number;
     height?: number;
   };
+  rotation?: number;
   points?: [number, number][];
   svg?: string;
   svgShape?: SvgShapeType;
@@ -36,6 +39,7 @@ export interface BoxSelector extends SupportedSelector {
     width: number;
     height: number;
   };
+  rotation?: number;
 }
 
 export interface PointSelector extends SupportedSelector {
@@ -44,6 +48,7 @@ export interface PointSelector extends SupportedSelector {
     x: number;
     y: number;
   };
+  rotation?: number;
 }
 
 export interface SvgSelector extends SupportedSelector {
@@ -58,6 +63,7 @@ export interface SvgSelector extends SupportedSelector {
     width: number;
     height: number;
   };
+  rotation?: number;
 }
 
 export interface TemporalSelector extends SupportedSelector {
@@ -66,6 +72,11 @@ export interface TemporalSelector extends SupportedSelector {
     startTime: number;
     endTime?: number;
   };
+}
+
+export interface RotationSelector extends SupportedSelector {
+  type: 'RotationSelector';
+  rotation: number;
 }
 
 export interface TemporalBoxSelector extends SupportedSelector {
@@ -77,15 +88,23 @@ export interface TemporalBoxSelector extends SupportedSelector {
     width: number;
     height: number;
   };
+  rotation?: number;
   temporal: {
     startTime: number;
     endTime?: number;
   };
 }
 
-export type SupportedSelectors = TemporalSelector | BoxSelector | TemporalBoxSelector | PointSelector | SvgSelector;
+export type SupportedSelectors =
+  | TemporalSelector
+  | BoxSelector
+  | TemporalBoxSelector
+  | PointSelector
+  | SvgSelector
+  | RotationSelector;
 
 export type ParsedSelector = {
   selector: SupportedSelectors | null;
   selectors: SupportedSelectors[];
+  iiifRenderingHints?: ImageApiSelector;
 };

--- a/src/annotation-targets/target-types.ts
+++ b/src/annotation-targets/target-types.ts
@@ -7,6 +7,12 @@ export type SupportedTarget = {
     | ExternalWebResource
     | { id: string; type: 'Unknown' | 'Canvas' | 'Range' | 'Manifest'; partOf?: Array<{ id: string; type: string }> };
   purpose?: string;
+  imageServiceHints?: {
+    size?: string;
+    rotation?: string;
+    quality?: string;
+    format?: string;
+  };
   selector: SupportedSelectors | null;
   selectors: SupportedSelectors[];
 };


### PR DESCRIPTION
Adds support to the expand-target helper to allow for `annotation.body.selector` to have a value like:
```json
{
  "@context": "http://iiif.io/api/annex/openannotation/context.json",
  "type": "iiif:ImageApiSelector",
  "region": "559,0,2666,2749"
}
```
and also:
```json
{
  "type": "ImageApiSelector",
  "region": "559,0,2666,2749"
}
```

Also adds a new "iiifRenderingHints" to parsed selectors, which contain non-selector information that might help with rendering canvases (`rotation`, `size`, `quality`, `format`)

Source: [https://iiif.io/api/annex/openannotation/#iiif-image-api-selector](https://iiif.io/api/annex/openannotation/#iiif-image-api-selector)

Additionally, any rotation will be detected and added to other selectors that have been picked up.

For example, annotation body:
```json
{
  "type": "SpecificResource",
  "resource": "https://example.org/image.jpg#xywh=559,0,2666,2749"
  "selector": {
    "type": "ImageApiSelector",
    "rotation": "90"
  }
}
```
Will provide a box selector like:
```json
{
  "type": "BoxSelector",
  "spatial": {
    "x": 559,
    "y": 0,
    "width": 2666,
    "height": 2749
  },
  "rotation": 90,
}
```